### PR TITLE
chore: Do not use expect

### DIFF
--- a/src/encoding/evm/approvals/permit2.rs
+++ b/src/encoding/evm/approvals/permit2.rs
@@ -3,7 +3,10 @@ use std::str::FromStr;
 use alloy_primitives::U256;
 use tycho_core::Bytes;
 
-use crate::encoding::user_approvals_manager::{Approval, UserApprovalsManager};
+use crate::encoding::{
+    errors::EncodingError,
+    user_approvals_manager::{Approval, UserApprovalsManager},
+};
 
 #[allow(dead_code)]
 pub struct Permit2 {
@@ -12,12 +15,13 @@ pub struct Permit2 {
 
 #[allow(dead_code)]
 impl Permit2 {
-    pub fn new() -> Self {
-        Self {
+    pub fn new() -> Result<Self, EncodingError> {
+        Ok(Self {
             address: Bytes::from_str("0x000000000022D473030F116dDEE9F6B43aC78BA3")
-                .expect("Permit2 address not valid"),
-        }
+                .map_err(|_| EncodingError::FatalError("Permit2 address not valid".to_string()))?,
+        })
     }
+
     fn get_allowance_data(
         &self,
         _user: Bytes,

--- a/src/encoding/evm/swap_encoder/encoders.rs
+++ b/src/encoding/evm/swap_encoder/encoders.rs
@@ -36,15 +36,14 @@ impl SwapEncoder for UniswapV2SwapEncoder {
 
 pub struct BalancerV2SwapEncoder {
     executor_address: String,
-    vault_address: Address,
+    vault_address: String,
 }
 
 impl SwapEncoder for BalancerV2SwapEncoder {
     fn new(executor_address: String) -> Self {
         Self {
             executor_address,
-            vault_address: Address::from_str("0xba12222222228d8ba445958a75a0704d566bf2c8")
-                .expect("Invalid string for balancer vault address"),
+            vault_address: "0xba12222222228d8ba445958a75a0704d566bf2c8".to_string(),
         }
     }
     fn encode_swap(
@@ -52,11 +51,15 @@ impl SwapEncoder for BalancerV2SwapEncoder {
         swap: Swap,
         encoding_context: EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
-        let token_approvals_manager = ProtocolApprovalsManager::new();
+        let token_approvals_manager = ProtocolApprovalsManager::new()?;
         let token = bytes_to_address(&swap.token_in)?;
         let router_address = bytes_to_address(&encoding_context.address_for_approvals)?;
-        let approval_needed =
-            token_approvals_manager.approval_needed(token, router_address, self.vault_address)?;
+        let approval_needed = token_approvals_manager.approval_needed(
+            token,
+            router_address,
+            Address::from_str(&self.vault_address)
+                .map_err(|_| EncodingError::FatalError("Invalid vault address".to_string()))?,
+        )?;
         // should we return gas estimation here too?? if there is an approval needed, gas will be
         // higher.
         let args = (

--- a/src/encoding/evm/swap_encoder/mod.rs
+++ b/src/encoding/evm/swap_encoder/mod.rs
@@ -9,6 +9,7 @@ use tycho_core::dto::Chain;
 
 use crate::encoding::evm::swap_encoder::registry::{Config, SwapEncoderRegistry};
 
+// TODO: init this at the higher level at some point
 lazy_static! {
     pub static ref SWAP_ENCODER_REGISTRY: RwLock<SwapEncoderRegistry> = {
         let config = Config::from_file("src/encoding/config/executor_addresses.json")

--- a/src/encoding/models.rs
+++ b/src/encoding/models.rs
@@ -1,15 +1,5 @@
-use std::{env, str::FromStr};
-
-use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use tycho_core::{dto::ProtocolComponent, Bytes};
-
-lazy_static! {
-    pub static ref PROPELLER_ROUTER_ADDRESS: Bytes = Bytes::from_str(
-        &env::var("ROUTER_ADDRESS").expect("Missing ROUTER_ADDRESS in environment"),
-    )
-    .expect("Invalid ROUTER_ADDRESS");
-}
 
 #[derive(Clone)]
 #[allow(dead_code)]


### PR DESCRIPTION
There are still one cases where I'm not sure what to do:

in swap_encoder/mod.rs
````

lazy_static! {
    pub static ref SWAP_ENCODER_REGISTRY: RwLock<SwapEncoderRegistry> = {
        let config = Config::from_file("src/encoding/config/executor_addresses.json")
            .expect("Failed to load configuration file");
        RwLock::new(SwapEncoderRegistry::new(config, Chain::Ethereum))
    };
}
````
I left a TODO there for future us!

