### PR TITLE
feat: Change signature of _handleCallback to take only bytes calldata

### DIFF
--- a/foundry/src/Dispatcher.sol
+++ b/foundry/src/Dispatcher.sol
@@ -82,11 +82,10 @@ contract Dispatcher {
         calculatedAmount = abi.decode(result, (uint256));
     }
 
-    function _handleCallback(
-        bytes4 selector,
-        address executor,
-        bytes memory data
-    ) internal {
+    function _handleCallback(bytes calldata data) internal {
+        bytes4 selector = bytes4(data[data.length - 4:]);
+        address executor = address(uint160(bytes20(data[data.length - 24:])));
+
         if (!executors[executor]) {
             revert Dispatcher__UnapprovedExecutor();
         }

--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -365,6 +365,8 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
         bytes calldata data
     ) external {
         if (data.length < 24) revert TychoRouter__InvalidDataLength();
+        // We are taking advantage of the fact that the data we need is already encoded in the correct format inside msg.data
+        // This way we preserve the bytes calldata (and don't need to convert it to bytes memory)
         uint256 dataOffset = 4 + 32 + 32 + 32; // Skip selector + 2 ints + data_offset
         uint256 dataLength =
             uint256(bytes32(msg.data[dataOffset:dataOffset + 32]));

--- a/foundry/test/executors/UniswapV3Executor.t.sol
+++ b/foundry/test/executors/UniswapV3Executor.t.sol
@@ -76,12 +76,17 @@ contract UniswapV3ExecutorTest is Test, Constants {
         uint256 initialPoolReserve = IERC20(WETH_ADDR).balanceOf(DAI_WETH_USV3);
 
         vm.startPrank(DAI_WETH_USV3);
+        bytes memory protocolData =
+            abi.encodePacked(WETH_ADDR, DAI_ADDR, poolFee);
+        uint256 dataOffset = 3; // some offset
+        uint256 dataLength = protocolData.length;
+
         bytes memory callbackData = abi.encodePacked(
             int256(amountOwed), // amount0Delta
             int256(0), // amount1Delta
-            WETH_ADDR,
-            DAI_ADDR,
-            poolFee
+            dataOffset,
+            dataLength,
+            protocolData
         );
         uniswapV3Exposed.handleCallback(callbackData);
         vm.stopPrank();
@@ -90,7 +95,7 @@ contract UniswapV3ExecutorTest is Test, Constants {
         assertEq(finalPoolReserve - initialPoolReserve, amountOwed);
     }
 
-    function testSwapWETHForDAI() public {
+    function testSwapIntegration() public {
         uint256 amountIn = 10 ** 18;
         deal(WETH_ADDR, address(uniswapV3Exposed), amountIn);
 


### PR DESCRIPTION
The selector and executor are decoded inside this function now. For Uniswap V3 I had to manually slice the msg.data from uniswapV3SwapCallback to get the data that matters for the callback

Took 3 hours 12 minutes

