### PR TITLE
feat: add multichain support in encoder

### DIFF
--- a/src/encoding/evm/approvals/permit2.rs
+++ b/src/encoding/evm/approvals/permit2.rs
@@ -23,7 +23,7 @@ use crate::encoding::{
         approvals::protocol_approvals_manager::get_client,
         utils::{biguint_to_u256, bytes_to_address, encode_input},
     },
-    models::{Chain, ChainId},
+    models::Chain,
 };
 
 /// Struct for managing Permit2 operations, including encoding approvals and fetching allowance
@@ -33,7 +33,7 @@ pub struct Permit2 {
     address: Address,
     client: Arc<RootProvider<BoxTransport>>,
     signer: PrivateKeySigner,
-    chain_id: ChainId,
+    chain_id: u64,
     runtime_handle: Handle,
     // Store the runtime to prevent it from being dropped before use.
     // This is required since tycho-execution does not have a pre-existing runtime.
@@ -160,7 +160,7 @@ impl Permit2 {
 
         let domain = eip712_domain! {
             name: "Permit2",
-            chain_id: self.chain_id.id(),
+            chain_id: self.chain_id,
             verifying_contract: self.address,
         };
         let hash = permit_single.eip712_signing_hash(&domain);

--- a/src/encoding/evm/tycho_encoder.rs
+++ b/src/encoding/evm/tycho_encoder.rs
@@ -26,16 +26,9 @@ impl EVMTychoEncoder {
         strategy_encoder: Box<dyn StrategyEncoder>,
     ) -> Result<Self, EncodingError> {
         let chain: Chain = Chain::from(chain);
-        if chain.name != *"ethereum" {
-            return Err(EncodingError::InvalidInput(
-                "Currently only Ethereum is supported".to_string(),
-            ));
-        }
-        Ok(EVMTychoEncoder {
-            strategy_encoder,
-            native_address: chain.native_token()?,
-            wrapped_address: chain.wrapped_token()?,
-        })
+        let native_address = chain.native_token()?;
+        let wrapped_address = chain.wrapped_token()?;
+        Ok(EVMTychoEncoder { strategy_encoder, native_address, wrapped_address })
     }
 }
 

--- a/src/encoding/evm/utils.rs
+++ b/src/encoding/evm/utils.rs
@@ -120,10 +120,3 @@ pub fn get_static_attribute(swap: &Swap, attribute_name: &str) -> Result<Vec<u8>
         })?
         .to_vec())
 }
-
-/// Decodes a hex string to a `Bytes` object.
-pub fn decode_hex(hex_str: &str, err_msg: &str) -> Result<Bytes, EncodingError> {
-    Ok(Bytes::from(
-        hex::decode(hex_str).map_err(|_| EncodingError::FatalError(err_msg.to_string()))?,
-    ))
-}

--- a/src/encoding/evm/utils.rs
+++ b/src/encoding/evm/utils.rs
@@ -120,3 +120,10 @@ pub fn get_static_attribute(swap: &Swap, attribute_name: &str) -> Result<Vec<u8>
         })?
         .to_vec())
 }
+
+/// Decodes a hex string to a `Bytes` object.
+pub fn decode_hex(hex_str: &str, err_msg: &str) -> Result<Bytes, EncodingError> {
+    Ok(Bytes::from(
+        hex::decode(hex_str).map_err(|_| EncodingError::FatalError(err_msg.to_string()))?,
+    ))
+}

--- a/src/encoding/models.rs
+++ b/src/encoding/models.rs
@@ -1,3 +1,4 @@
+use hex;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use tycho_core::{
@@ -5,7 +6,6 @@ use tycho_core::{
     Bytes,
 };
 
-use super::evm::utils::decode_hex;
 use crate::encoding::{
     errors::EncodingError,
     serde_primitives::{biguint_string, biguint_string_option},
@@ -138,13 +138,19 @@ impl From<TychoCoreChain> for Chain {
 }
 
 impl Chain {
+    fn decode_hex(&self, hex_str: &str, err_msg: &str) -> Result<Bytes, EncodingError> {
+        Ok(Bytes::from(
+            hex::decode(hex_str).map_err(|_| EncodingError::FatalError(err_msg.to_string()))?,
+        ))
+    }
+
     pub fn native_token(&self) -> Result<Bytes, EncodingError> {
         let decode_err_msg = "Failed to decode native token";
         match self.id {
             1 | 8453 | 42161 => {
-                decode_hex("0000000000000000000000000000000000000000", decode_err_msg)
+                self.decode_hex("0000000000000000000000000000000000000000", decode_err_msg)
             }
-            324 => decode_hex("000000000000000000000000000000000000800A", decode_err_msg),
+            324 => self.decode_hex("000000000000000000000000000000000000800A", decode_err_msg),
             _ => Err(EncodingError::InvalidInput(format!(
                 "Native token not set for chain {:?}. Double check the chain is supported.",
                 self.name
@@ -155,10 +161,10 @@ impl Chain {
     pub fn wrapped_token(&self) -> Result<Bytes, EncodingError> {
         let decode_err_msg = "Failed to decode wrapped token";
         match self.id {
-            1 => decode_hex("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", decode_err_msg),
-            8453 => decode_hex("4200000000000000000000000000000000000006", decode_err_msg),
-            324 => decode_hex("5AEa5775959fBC2557Cc8789bC1bf90A239D9a91", decode_err_msg),
-            42161 => decode_hex("82aF49447D8a07e3bd95BD0d56f35241523fBab1", decode_err_msg),
+            1 => self.decode_hex("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", decode_err_msg),
+            8453 => self.decode_hex("4200000000000000000000000000000000000006", decode_err_msg),
+            324 => self.decode_hex("5AEa5775959fBC2557Cc8789bC1bf90A239D9a91", decode_err_msg),
+            42161 => self.decode_hex("82aF49447D8a07e3bd95BD0d56f35241523fBab1", decode_err_msg),
             _ => Err(EncodingError::InvalidInput(format!(
                 "Wrapped token not set for chain {:?}. Double check the chain is supported.",
                 self.name


### PR DESCRIPTION
Added `native_token`, `wrapped_token`, `dai_address`, `usdc_address` for the following networks:
 - Base
 - ZkSync
 - Arbitrum