### PR TITLE
refactor: remove unnecessary checks from _unwrapEth

### DIFF
--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -441,9 +441,6 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
      * @param amount of WETH to unwrap.
      */
     function _unwrapETH(uint256 amount) internal {
-        if (amount == 0) {
-            revert TychoRouter__AmountZero();
-        }
         _weth.withdraw(amount);
     }
 

--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -56,6 +56,7 @@ import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 //           ✷✷✷✷✷✷               ✷✷✷✷✷              ✷✷✷✷✷✷✷✷        ✷✷✷✷✷✷      ✷✷✷✷✷✷         ✷✷✷✷✷✷✷✷
 
 error TychoRouter__AddressZero();
+error TychoRouter__AmountZero();
 error TychoRouter__EmptySwaps();
 error TychoRouter__NegativeSlippage(uint256 amount, uint256 minAmount);
 error TychoRouter__AmountInNotFullySpent(uint256 leftoverAmount);
@@ -440,13 +441,14 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
      * @param amount of WETH to unwrap.
      */
     function _unwrapETH(uint256 amount) internal {
-        uint256 unwrapAmount =
-            amount == 0 ? _weth.balanceOf(address(this)) : amount;
-        _weth.withdraw(unwrapAmount);
+        if (amount == 0) {
+            revert TychoRouter__AmountZero();
+        }
+        _weth.withdraw(amount);
     }
 
     /**
-     * @dev Allows this contract to receive native token
+     * @dev Allows this contract to receive native token from contracts
      */
     receive() external payable {
         require(msg.sender.code.length != 0);

--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -448,7 +448,7 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
     }
 
     /**
-     * @dev Allows this contract to receive native token from contracts
+     * @dev Allows this contract to receive native token with empty msg.data from contracts
      */
     receive() external payable {
         require(msg.sender.code.length != 0);


### PR DESCRIPTION
Remove unnecessary checks from _unwrapEth, and only check the amount