### PR TITLE
feat: Rename ETH_RPC_URL -> RPC_URL

### DIFF
--- a/.github/workflows/tests-and-lints-template.yaml
+++ b/.github/workflows/tests-and-lints-template.yaml
@@ -25,7 +25,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  ETH_RPC_URL: ${{ secrets.eth_rpc_url }}
+  RPC_URL: ${{ secrets.eth_rpc_url }}
 
 jobs:
   compile_and_test:

--- a/src/encoding/evm/approvals/permit2.rs
+++ b/src/encoding/evm/approvals/permit2.rs
@@ -269,7 +269,7 @@ mod tests {
 
     /// This test actually calls the permit method on the Permit2 contract to verify the encoded
     /// data works. It requires an Anvil fork, so please run with the following command: anvil
-    /// --fork-url <RPC-URL> And set up the following env var as ETH_RPC_URL=127.0.0.1:8545
+    /// --fork-url <RPC-URL> And set up the following env var as RPC_URL=127.0.0.1:8545
     /// Use an account from anvil to fill the anvil_account and anvil_private_key variables
     #[test]
     #[cfg_attr(not(feature = "fork-tests"), ignore)]

--- a/src/encoding/evm/approvals/protocol_approvals_manager.rs
+++ b/src/encoding/evm/approvals/protocol_approvals_manager.rs
@@ -75,8 +75,8 @@ impl ProtocolApprovalsManager {
 /// Gets the client used for interacting with the EVM-compatible network.
 pub async fn get_client() -> Result<Arc<RootProvider<BoxTransport>>, EncodingError> {
     dotenv().ok();
-    let eth_rpc_url = env::var("ETH_RPC_URL")
-        .map_err(|_| EncodingError::FatalError("Missing ETH_RPC_URL in environment".to_string()))?;
+    let eth_rpc_url = env::var("RPC_URL")
+        .map_err(|_| EncodingError::FatalError("Missing RPC_URL in environment".to_string()))?;
     let client = ProviderBuilder::new()
         .on_builtin(&eth_rpc_url)
         .await


### PR DESCRIPTION
We support multiple chains so this may not just be ETH, but perhaps a Base URL for example.