### PR TITLE
feat: Rename shortcut methods of encoder builder

### DIFF
--- a/examples/encoding-example/main.rs
+++ b/examples/encoding-example/main.rs
@@ -23,7 +23,7 @@ fn main() {
     // Initialize the encoder
     let encoder = EVMEncoderBuilder::new()
         .chain(Chain::Ethereum)
-        .tycho_router_with_permit2(None, swapper_pk)
+        .initialize_tycho_router_with_permit2(swapper_pk)
         .expect("Failed to create encoder builder")
         .build()
         .expect("Failed to build encoder");


### PR DESCRIPTION
Also moved executors_file_path to be an independent attribute.

[Jira task](https://datarevenue.atlassian.net/jira/software/projects/ENG/boards/24?selectedIssue=ENG-4286)

Corresponding PRs:
- [docs](https://app.gitbook.com/o/9wMvRDQIhk1xOsIZ0Zde/s/jrIe0oInIEt65tHqWn2w/~/changes/46/for-solvers/execution/encoding)
- [update quickstart](https://github.com/propeller-heads/tycho-simulation/pull/159)