### PR TITLE
fix: remove redundant target verification in USV3 executor

### DIFF
--- a/foundry/src/executors/UniswapV3Executor.sol
+++ b/foundry/src/executors/UniswapV3Executor.sol
@@ -13,8 +13,6 @@ error UniswapV3Executor__InvalidFactory();
 contract UniswapV3Executor is IExecutor, ICallback {
     using SafeERC20 for IERC20;
 
-    bytes32 internal constant POOL_INIT_CODE_HASH =
-        0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
     uint160 private constant MIN_SQRT_RATIO = 4295128739;
     uint160 private constant MAX_SQRT_RATIO =
         1461446703485210103287273052203988822378723970342;

--- a/foundry/src/executors/UniswapV3Executor.sol
+++ b/foundry/src/executors/UniswapV3Executor.sol
@@ -9,7 +9,6 @@ import "@interfaces/ICallback.sol";
 
 error UniswapV3Executor__InvalidDataLength();
 error UniswapV3Executor__InvalidFactory();
-error UniswapV3Executor__InvalidTarget();
 
 contract UniswapV3Executor is IExecutor, ICallback {
     using SafeERC20 for IERC20;
@@ -45,8 +44,6 @@ contract UniswapV3Executor is IExecutor, ICallback {
             address target,
             bool zeroForOne
         ) = _decodeData(data);
-
-        _verifyPairAddress(tokenIn, tokenOut, fee, target);
 
         int256 amount0;
         int256 amount1;
@@ -149,32 +146,5 @@ contract UniswapV3Executor is IExecutor, ICallback {
         returns (bytes memory)
     {
         return abi.encodePacked(tokenIn, tokenOut, fee, self);
-    }
-
-    function _verifyPairAddress(
-        address tokenA,
-        address tokenB,
-        uint24 fee,
-        address target
-    ) internal view {
-        (address token0, address token1) =
-            tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
-        address pool = address(
-            uint160(
-                uint256(
-                    keccak256(
-                        abi.encodePacked(
-                            hex"ff",
-                            factory,
-                            keccak256(abi.encode(token0, token1, fee)),
-                            POOL_INIT_CODE_HASH
-                        )
-                    )
-                )
-            )
-        );
-        if (pool != target) {
-            revert UniswapV3Executor__InvalidTarget();
-        }
     }
 }

--- a/foundry/test/executors/UniswapV3Executor.t.sol
+++ b/foundry/test/executors/UniswapV3Executor.t.sol
@@ -22,15 +22,6 @@ contract UniswapV3ExecutorExposed is UniswapV3Executor {
     {
         return _decodeData(data);
     }
-
-    function verifyPairAddress(
-        address tokenA,
-        address tokenB,
-        uint24 fee,
-        address target
-    ) external view {
-        _verifyPairAddress(tokenA, tokenB, fee, target);
-    }
 }
 
 contract UniswapV3ExecutorTest is Test, Constants {
@@ -78,10 +69,12 @@ contract UniswapV3ExecutorTest is Test, Constants {
         uniswapV3Exposed.decodeData(invalidParams);
     }
 
-    function testVerifyPairAddress() public view {
-        uniswapV3Exposed.verifyPairAddress(
-            WETH_ADDR, DAI_ADDR, 3000, DAI_WETH_USV3
-        );
+    function testVerifyCallbackFailure() public {
+        vm.startPrank(DUMMY); // contract with minimal code
+        bytes memory data = abi.encodePacked(WETH_ADDR, DAI_ADDR, uint24(3000));
+        vm.expectRevert();
+        uniswapV3Exposed.verifyCallback(data);
+        vm.stopPrank();
     }
 
     function testUSV3Callback() public {
@@ -143,7 +136,7 @@ contract UniswapV3ExecutorTest is Test, Constants {
             zeroForOne
         );
 
-        vm.expectRevert(UniswapV3Executor__InvalidTarget.selector);
+        vm.expectRevert();
         uniswapV3Exposed.swap(amountIn, protocolData);
     }
 


### PR DESCRIPTION
Removed the target verification from the Uniswap V3 executor because we are already doing it [here](https://github.com/Uniswap/v3-periphery/blob/0682387198a24c7cd63566a2c58398533860a5d1/contracts/libraries/CallbackValidation.sol#L33) in the `verifyCallback`. 