### PR TITLE
fix: inequality check for amountConsumed and amountIn

### DIFF
--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -59,7 +59,7 @@ error TychoRouter__AddressZero();
 error TychoRouter__AmountZero();
 error TychoRouter__EmptySwaps();
 error TychoRouter__NegativeSlippage(uint256 amount, uint256 minAmount);
-error TychoRouter__AmountInNotFullySpent(uint256 leftoverAmount);
+error TychoRouter__AmountInDiffersFromConsumed(uint256 amountConsumed);
 error TychoRouter__MessageValueMismatch(uint256 value, uint256 amount);
 error TychoRouter__InvalidDataLength();
 
@@ -163,9 +163,8 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
 
         uint256 amountConsumed = initialBalance - currentBalance;
 
-        if (amountConsumed < amountIn) {
-            uint256 leftoverAmount = amountIn - amountConsumed;
-            revert TychoRouter__AmountInNotFullySpent(leftoverAmount);
+        if (amountConsumed != amountIn) {
+            revert TychoRouter__AmountInDiffersFromConsumed(amountConsumed);
         }
 
         if (fee > 0) {

--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -59,7 +59,9 @@ error TychoRouter__AddressZero();
 error TychoRouter__AmountZero();
 error TychoRouter__EmptySwaps();
 error TychoRouter__NegativeSlippage(uint256 amount, uint256 minAmount);
-error TychoRouter__AmountInDiffersFromConsumed(uint256 amountConsumed);
+error TychoRouter__AmountInDiffersFromConsumed(
+    uint256 amountIn, uint256 amountConsumed
+);
 error TychoRouter__MessageValueMismatch(uint256 value, uint256 amount);
 error TychoRouter__InvalidDataLength();
 
@@ -164,7 +166,9 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
         uint256 amountConsumed = initialBalance - currentBalance;
 
         if (amountConsumed != amountIn) {
-            revert TychoRouter__AmountInDiffersFromConsumed(amountConsumed);
+            revert TychoRouter__AmountInDiffersFromConsumed(
+                amountIn, amountConsumed
+            );
         }
 
         if (fee > 0) {

--- a/foundry/test/TychoRouter.t.sol
+++ b/foundry/test/TychoRouter.t.sol
@@ -895,7 +895,8 @@ contract TychoRouterTest is TychoRouterTestSetup {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                TychoRouter__AmountInNotFullySpent.selector, 400000000000000000
+                TychoRouter__AmountInDiffersFromConsumed.selector,
+                600000000000000000
             )
         );
 

--- a/foundry/test/TychoRouter.t.sol
+++ b/foundry/test/TychoRouter.t.sol
@@ -896,6 +896,7 @@ contract TychoRouterTest is TychoRouterTestSetup {
         vm.expectRevert(
             abi.encodeWithSelector(
                 TychoRouter__AmountInDiffersFromConsumed.selector,
+                1000000000000000000,
                 600000000000000000
             )
         );


### PR DESCRIPTION
Checks if `amountConsumed` is not equal to `amountIn`, reverts with `amountConsumed`