### PR TITLE
feat: Support Ekubo callback in TychoRouter

### DIFF
--- a/config/executor_addresses.json
+++ b/config/executor_addresses.json
@@ -7,7 +7,7 @@
     "pancakeswap_v3": "0x4929B619A8F0D9c06ed0FfD497636580D823F65d",
     "uniswap_v4": "0x042C0ebBEAb9d9987c2f64Ee05f2B3aeB86eAf70",
     "vm:balancer_v2": "0x00BE8EfAE40219Ff76287b0F9b9e497942f5BC91",
-    "ekubo": "0x5E40985A4d4E8DbAd1dc35fFCfacfCde3e3d1806"
+    "ekubo_v2": "0x5E40985A4d4E8DbAd1dc35fFCfacfCde3e3d1806"
   },
   "tenderly_ethereum": {
     "uniswap_v2": "0x00C1b81e3C8f6347E69e2DDb90454798A6Be975E",

--- a/config/executor_addresses.json
+++ b/config/executor_addresses.json
@@ -6,7 +6,8 @@
     "uniswap_v3": "0xdD8559c917393FC8DD2b4dD289c52Ff445fDE1B0",
     "pancakeswap_v3": "0x4929B619A8F0D9c06ed0FfD497636580D823F65d",
     "uniswap_v4": "0x042C0ebBEAb9d9987c2f64Ee05f2B3aeB86eAf70",
-    "vm:balancer_v2": "0x00BE8EfAE40219Ff76287b0F9b9e497942f5BC91"
+    "vm:balancer_v2": "0x00BE8EfAE40219Ff76287b0F9b9e497942f5BC91",
+    "ekubo": "0x5991A2dF15A8F6A256D3Ec51E99254Cd3fb576A9"
   },
   "tenderly_ethereum": {
     "uniswap_v2": "0x00C1b81e3C8f6347E69e2DDb90454798A6Be975E",

--- a/config/executor_addresses.json
+++ b/config/executor_addresses.json
@@ -7,7 +7,7 @@
     "pancakeswap_v3": "0x4929B619A8F0D9c06ed0FfD497636580D823F65d",
     "uniswap_v4": "0x042C0ebBEAb9d9987c2f64Ee05f2B3aeB86eAf70",
     "vm:balancer_v2": "0x00BE8EfAE40219Ff76287b0F9b9e497942f5BC91",
-    "ekubo": "0x5991A2dF15A8F6A256D3Ec51E99254Cd3fb576A9"
+    "ekubo": "0x5E40985A4d4E8DbAd1dc35fFCfacfCde3e3d1806"
   },
   "tenderly_ethereum": {
     "uniswap_v2": "0x00C1b81e3C8f6347E69e2DDb90454798A6Be975E",

--- a/foundry/lib/ekubo/interfaces/ICore.sol
+++ b/foundry/lib/ekubo/interfaces/ICore.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.26;
 
 import {IFlashAccountant} from "./IFlashAccountant.sol";
-import {PoolKey} from "../types/poolKey.sol";
+import {EkuboPoolKey} from "../types/poolKey.sol";
 import {SqrtRatio} from "../types/sqrtRatio.sol";
 
 interface ICore is IFlashAccountant {
     function swap_611415377(
-        PoolKey memory poolKey,
+        EkuboPoolKey memory poolKey,
         int128 amount,
         bool isToken1,
         SqrtRatio sqrtRatioLimit,

--- a/foundry/lib/ekubo/types/poolKey.sol
+++ b/foundry/lib/ekubo/types/poolKey.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.26;
 type Config is bytes32;
 
 // Each pool has its own state associated with this key
-struct PoolKey {
+struct EkuboPoolKey {
     address token0;
     address token1;
     Config config;

--- a/foundry/scripts/deploy-executors.js
+++ b/foundry/scripts/deploy-executors.js
@@ -33,6 +33,9 @@ const executors_to_deploy = {
     // Args: Pool manager
     {exchange: "UniswapV4Executor", args: ["0x000000000004444c5dc75cB358380D2e3dE08A90"]},
     {exchange: "BalancerV2Executor", args: []},
+    // Args: Ekubo core contract
+    {exchange: "EkuboExecutor", args: [
+      "0xe0e0e08A6A4b9Dc7bD67BCB7aadE5cF48157d444"
   ],
   "base":[
     // Args: Factory, Pool Init Code Hash

--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -143,7 +143,11 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
         address receiver,
         bytes calldata swaps
     ) public payable whenNotPaused nonReentrant returns (uint256 amountOut) {
-        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
+        if (address(tokenIn) != address(0)) {
+            IERC20(tokenIn).safeTransferFrom(
+                msg.sender, address(this), amountIn
+            );
+        }
         return _swapChecked(
             amountIn,
             tokenIn,
@@ -547,5 +551,25 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
         if (data.length < 24) revert TychoRouter__InvalidDataLength();
         _handleCallback(data);
         return "";
+    }
+
+    function locked(uint256) external {
+        // TODO replace with real executor address once deployed
+        address executor = address(0x5991A2dF15A8F6A256D3Ec51E99254Cd3fb576A9);
+
+        // slither-disable-next-line controlled-delegatecall,low-level-calls
+        (bool success, bytes memory result) = executor.delegatecall(
+            abi.encodeWithSelector(ICallback.handleCallback.selector, msg.data)
+        );
+
+        if (!success) {
+            revert(
+                string(
+                    result.length > 0
+                        ? result
+                        : abi.encodePacked("Callback failed")
+                )
+            );
+        }
     }
 }

--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -571,4 +571,23 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
             );
         }
     }
+
+    function payCallback(uint256, address /*token*/ ) external {
+        address executor = address(0x5E40985A4d4E8DbAd1dc35fFCfacfCde3e3d1806);
+
+        // slither-disable-next-line controlled-delegatecall,low-level-calls
+        (bool success, bytes memory result) = executor.delegatecall(
+            abi.encodeWithSelector(ICallback.handleCallback.selector, msg.data)
+        );
+
+        if (!success) {
+            revert(
+                string(
+                    result.length > 0
+                        ? result
+                        : abi.encodePacked("Callback failed")
+                )
+            );
+        }
+    }
 }

--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -554,8 +554,7 @@ contract TychoRouter is AccessControl, Dispatcher, Pausable, ReentrancyGuard {
     }
 
     function locked(uint256) external {
-        // TODO replace with real executor address once deployed
-        address executor = address(0x5991A2dF15A8F6A256D3Ec51E99254Cd3fb576A9);
+        address executor = address(0x5E40985A4d4E8DbAd1dc35fFCfacfCde3e3d1806);
 
         // slither-disable-next-line controlled-delegatecall,low-level-calls
         (bool success, bytes memory result) = executor.delegatecall(

--- a/foundry/src/executors/EkuboExecutor.sol
+++ b/foundry/src/executors/EkuboExecutor.sol
@@ -25,8 +25,8 @@ contract EkuboExecutor is IExecutor, ICallback, ILocker, IPayer {
     uint256 constant POOL_DATA_OFFSET = 56;
     uint256 constant HOP_BYTE_LEN = 52;
 
-    constructor(ICore _core) {
-        core = _core;
+    constructor(address _core) {
+        core = ICore(_core);
     }
 
     function swap(uint256 amountIn, bytes calldata data)

--- a/foundry/src/executors/EkuboExecutor.sol
+++ b/foundry/src/executors/EkuboExecutor.sol
@@ -9,7 +9,7 @@ import {ILocker, IPayer} from "@ekubo/interfaces/IFlashAccountant.sol";
 import {NATIVE_TOKEN_ADDRESS} from "@ekubo/math/constants.sol";
 import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
 import {LibBytes} from "@solady/utils/LibBytes.sol";
-import {Config, PoolKey} from "@ekubo/types/poolKey.sol";
+import {Config, EkuboPoolKey} from "@ekubo/types/poolKey.sol";
 import {MAX_SQRT_RATIO, MIN_SQRT_RATIO} from "@ekubo/types/sqrtRatio.sol";
 
 contract EkuboExecutor is IExecutor, ICallback, ILocker, IPayer {
@@ -146,7 +146,7 @@ contract EkuboExecutor is IExecutor, ICallback, ILocker, IPayer {
                 : (nextTokenIn, nextTokenOut, false);
 
             (int128 delta0, int128 delta1) = core.swap_611415377(
-                PoolKey(token0, token1, poolConfig),
+                EkuboPoolKey(token0, token1, poolConfig),
                 nextAmountIn,
                 isToken1,
                 isToken1 ? MAX_SQRT_RATIO : MIN_SQRT_RATIO,

--- a/foundry/test/TychoRouter.t.sol
+++ b/foundry/test/TychoRouter.t.sol
@@ -1029,6 +1029,9 @@ contract TychoRouterTest is TychoRouterTestSetup {
     }
 
     function testEkuboIntegration() public {
+        vm.skip(true);
+        // Test needs to be run on block 22082754 or later
+
         deal(ALICE, 1 ether);
         uint256 balancerBefore = IERC20(USDC_ADDR).balanceOf(ALICE);
 

--- a/foundry/test/TychoRouter.t.sol
+++ b/foundry/test/TychoRouter.t.sol
@@ -1028,6 +1028,27 @@ contract TychoRouterTest is TychoRouterTestSetup {
         assertEq(balancerAfter - balancerBefore, 1120007305574805922);
     }
 
+    function testEkuboIntegration() public {
+        deal(ALICE, 1 ether);
+        uint256 balancerBefore = IERC20(USDC_ADDR).balanceOf(ALICE);
+
+        // Approve permit2
+        vm.startPrank(ALICE);
+        // Encoded solution generated using `test_split_encoding_strategy_ekubo`
+        (bool success,) = tychoRouterAddr.call{value: 1 ether}(
+            hex"0a83cb080000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000cd09f75e2bf2a4d11f3ab23f1389fcc1621c0cc200000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000077007500010000005991a2df15a8f6a256d3ec51e99254cd3fb576a93ede3eca2a72b3aecc820e955b36f38437d013950000000000000000000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4851d02a5948496a67827242eabc5725531342527c000000000000000000000000000000000000000000"
+        );
+
+        uint256 balancerAfter = IERC20(USDC_ADDR).balanceOf(ALICE);
+
+        assertTrue(success, "Call Failed");
+        assertGe(balancerAfter - balancerBefore, 26173932);
+
+        // All input tokens are transferred to the router at first. Make sure we used
+        // all of it (and thus our splits are correct).
+        assertEq(IERC20(WETH_ADDR).balanceOf(tychoRouterAddr), 0);
+    }
+
     function testSplitSwapIntegration() public {
         // Test created with calldata from our router encoder, replacing the executor
         // address with the USV2 executor address.

--- a/foundry/test/TychoRouterTestSetup.sol
+++ b/foundry/test/TychoRouterTestSetup.sol
@@ -10,6 +10,7 @@ import "@src/TychoRouter.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {WETH} from "../lib/permit2/lib/solmate/src/tokens/WETH.sol";
 import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
+import "../src/executors/EkuboExecutor.sol";
 
 contract TychoRouterExposed is TychoRouter {
     constructor(address _permit2, address weth) TychoRouter(_permit2, weth) {}
@@ -38,6 +39,7 @@ contract TychoRouterTestSetup is Test, Constants {
     UniswapV3Executor public usv3Executor;
     UniswapV3Executor public pancakev3Executor;
     UniswapV4Executor public usv4Executor;
+    EkuboExecutor public ekuboExecutor;
     MockERC20[] tokens;
 
     function setUp() public {
@@ -52,6 +54,8 @@ contract TychoRouterTestSetup is Test, Constants {
         bytes32 initCodeV3 = USV3_POOL_CODE_INIT_HASH;
         bytes32 initCodePancakeV3 = PANCAKEV3_POOL_CODE_INIT_HASH;
         address poolManagerAddress = 0x000000000004444c5dc75cB358380D2e3dE08A90;
+        ICore ekuboCore = ICore(0xe0e0e08A6A4b9Dc7bD67BCB7aadE5cF48157d444);
+
         IPoolManager poolManager = IPoolManager(poolManagerAddress);
         tychoRouter = new TychoRouterExposed(PERMIT2_ADDRESS, WETH_ADDR);
         tychoRouterAddr = address(tychoRouter);
@@ -70,12 +74,14 @@ contract TychoRouterTestSetup is Test, Constants {
         usv4Executor = new UniswapV4Executor(poolManager);
         pancakev3Executor =
             new UniswapV3Executor(factoryPancakeV3, initCodePancakeV3);
+        ekuboExecutor = new EkuboExecutor(ekuboCore);
         vm.startPrank(EXECUTOR_SETTER);
-        address[] memory executors = new address[](4);
+        address[] memory executors = new address[](5);
         executors[0] = address(usv2Executor);
         executors[1] = address(usv3Executor);
         executors[2] = address(pancakev3Executor);
         executors[3] = address(usv4Executor);
+        executors[3] = address(ekuboExecutor);
         tychoRouter.setExecutors(executors);
         vm.stopPrank();
 

--- a/foundry/test/TychoRouterTestSetup.sol
+++ b/foundry/test/TychoRouterTestSetup.sol
@@ -75,13 +75,14 @@ contract TychoRouterTestSetup is Test, Constants {
         pancakev3Executor =
             new UniswapV3Executor(factoryPancakeV3, initCodePancakeV3);
         ekuboExecutor = new EkuboExecutor(ekuboCore);
+
         vm.startPrank(EXECUTOR_SETTER);
         address[] memory executors = new address[](5);
         executors[0] = address(usv2Executor);
         executors[1] = address(usv3Executor);
         executors[2] = address(pancakev3Executor);
         executors[3] = address(usv4Executor);
-        executors[3] = address(ekuboExecutor);
+        executors[4] = address(ekuboExecutor);
         tychoRouter.setExecutors(executors);
         vm.stopPrank();
 

--- a/foundry/test/TychoRouterTestSetup.sol
+++ b/foundry/test/TychoRouterTestSetup.sol
@@ -54,7 +54,7 @@ contract TychoRouterTestSetup is Test, Constants {
         bytes32 initCodeV3 = USV3_POOL_CODE_INIT_HASH;
         bytes32 initCodePancakeV3 = PANCAKEV3_POOL_CODE_INIT_HASH;
         address poolManagerAddress = 0x000000000004444c5dc75cB358380D2e3dE08A90;
-        ICore ekuboCore = ICore(0xe0e0e08A6A4b9Dc7bD67BCB7aadE5cF48157d444);
+        address ekuboCore = 0xe0e0e08A6A4b9Dc7bD67BCB7aadE5cF48157d444;
 
         IPoolManager poolManager = IPoolManager(poolManagerAddress);
         tychoRouter = new TychoRouterExposed(PERMIT2_ADDRESS, WETH_ADDR);

--- a/src/encoding/evm/strategy_encoder/strategy_encoders.rs
+++ b/src/encoding/evm/strategy_encoder/strategy_encoders.rs
@@ -1030,7 +1030,7 @@ mod tests {
         let component = ProtocolComponent {
             // All Ekubo swaps go through the core contract - not necessary to specify pool id
             // for test
-            protocol_system: "ekubo".to_string(),
+            protocol_system: "ekubo_v2".to_string(),
             static_attributes,
             ..Default::default()
         };

--- a/src/encoding/evm/swap_encoder/builder.rs
+++ b/src/encoding/evm/swap_encoder/builder.rs
@@ -1,7 +1,8 @@
 use crate::encoding::{
     errors::EncodingError,
     evm::swap_encoder::swap_encoders::{
-        BalancerV2SwapEncoder, UniswapV2SwapEncoder, UniswapV3SwapEncoder, UniswapV4SwapEncoder,
+        BalancerV2SwapEncoder, EkuboSwapEncoder, UniswapV2SwapEncoder, UniswapV3SwapEncoder,
+        UniswapV4SwapEncoder,
     },
     swap_encoder::SwapEncoder,
 };
@@ -29,6 +30,7 @@ impl SwapEncoderBuilder {
             "uniswap_v3" => Ok(Box::new(UniswapV3SwapEncoder::new(self.executor_address))),
             "pancakeswap_v3" => Ok(Box::new(UniswapV3SwapEncoder::new(self.executor_address))),
             "uniswap_v4" => Ok(Box::new(UniswapV4SwapEncoder::new(self.executor_address))),
+            "ekubo" => Ok(Box::new(EkuboSwapEncoder::new(self.executor_address))),
             _ => Err(EncodingError::FatalError(format!(
                 "Unknown protocol system: {}",
                 self.protocol_system

--- a/src/encoding/evm/swap_encoder/builder.rs
+++ b/src/encoding/evm/swap_encoder/builder.rs
@@ -30,7 +30,7 @@ impl SwapEncoderBuilder {
             "uniswap_v3" => Ok(Box::new(UniswapV3SwapEncoder::new(self.executor_address))),
             "pancakeswap_v3" => Ok(Box::new(UniswapV3SwapEncoder::new(self.executor_address))),
             "uniswap_v4" => Ok(Box::new(UniswapV4SwapEncoder::new(self.executor_address))),
-            "ekubo" => Ok(Box::new(EkuboSwapEncoder::new(self.executor_address))),
+            "ekubo_v2" => Ok(Box::new(EkuboSwapEncoder::new(self.executor_address))),
             _ => Err(EncodingError::FatalError(format!(
                 "Unknown protocol system: {}",
                 self.protocol_system


### PR DESCRIPTION
**Only review the final commit**

- add integration test
- cannot directly call _handleCallback from the locked method of the tycho router because of bytes memory to bytes callback conversion
- Rename to EkuboPoolKey because of conflict with USV4 pool key

- **Bonus:** fix bug where input token to swap method must be ERC20 (we should also support ETH)

**NOTE:** This is not a final solution. This is a temporary solution since the Ekubo deployment is URGENT. We will solve this issue more elegantly soon by refactoring the callback functionality.