### PR TITLE
feat: Select strategy in TychoRouterEncoder depending on the solution

### DIFF
--- a/src/encoding/evm/approvals/permit2.rs
+++ b/src/encoding/evm/approvals/permit2.rs
@@ -175,7 +175,7 @@ mod tests {
 
     use alloy_primitives::Uint;
     use num_bigint::BigUint;
-    use tycho_common::models::Chain as TychoCoreChain;
+    use tycho_common::models::Chain as TychoCommonChain;
 
     use super::*;
 
@@ -211,7 +211,7 @@ mod tests {
     }
 
     fn eth_chain() -> Chain {
-        TychoCoreChain::Ethereum.into()
+        TychoCommonChain::Ethereum.into()
     }
 
     #[test]

--- a/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
+++ b/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
@@ -17,11 +17,7 @@ pub struct SwapEncoderRegistry {
 impl SwapEncoderRegistry {
     /// Populates the registry with the `SwapEncoders` for the given blockchain by parsing the
     /// executors' addresses in the file at the given path.
-    pub fn new(
-        executors_file_path: Option<String>,
-        blockchain: tycho_common::models::Chain,
-    ) -> Result<Self, EncodingError> {
-        let chain = Chain::from(blockchain);
+    pub fn new(executors_file_path: Option<String>, chain: Chain) -> Result<Self, EncodingError> {
         let config_str = if let Some(ref path) = executors_file_path {
             fs::read_to_string(path).map_err(|e| {
                 EncodingError::FatalError(format!(

--- a/src/encoding/models.rs
+++ b/src/encoding/models.rs
@@ -2,7 +2,7 @@ use hex;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use tycho_common::{
-    models::{protocol::ProtocolComponent, Chain as TychoCoreChain},
+    models::{protocol::ProtocolComponent, Chain as TychoCommonChain},
     Bytes,
 };
 
@@ -121,15 +121,15 @@ pub struct Chain {
     pub name: String,
 }
 
-impl From<TychoCoreChain> for Chain {
-    fn from(chain: TychoCoreChain) -> Self {
+impl From<TychoCommonChain> for Chain {
+    fn from(chain: TychoCommonChain) -> Self {
         match chain {
-            TychoCoreChain::Ethereum => Chain { id: 1, name: chain.to_string() },
-            TychoCoreChain::ZkSync => Chain { id: 324, name: chain.to_string() },
-            TychoCoreChain::Arbitrum => Chain { id: 42161, name: chain.to_string() },
-            TychoCoreChain::Starknet => Chain { id: 0, name: chain.to_string() },
-            TychoCoreChain::Base => Chain { id: 8453, name: chain.to_string() },
-            TychoCoreChain::Unichain => Chain { id: 130, name: chain.to_string() },
+            TychoCommonChain::Ethereum => Chain { id: 1, name: chain.to_string() },
+            TychoCommonChain::ZkSync => Chain { id: 324, name: chain.to_string() },
+            TychoCommonChain::Arbitrum => Chain { id: 42161, name: chain.to_string() },
+            TychoCommonChain::Starknet => Chain { id: 0, name: chain.to_string() },
+            TychoCommonChain::Base => Chain { id: 8453, name: chain.to_string() },
+            TychoCommonChain::Unichain => Chain { id: 130, name: chain.to_string() },
         }
     }
 }


### PR DESCRIPTION
- The tycho router address default is set at the EncoderBuilder level (not inside the strategies)
- Rename TychoCoreChain to TychoCommonChain
- Only take TychoCommonChain as an argument at the outermost level: EncoderBuilder. Everywhere else we use the execution Chain right away