### PR TITLE
fix: Configurable fee on USV2 executor.

### DIFF
--- a/foundry/scripts/deploy-executors.js
+++ b/foundry/scripts/deploy-executors.js
@@ -5,25 +5,28 @@ const hre = require("hardhat");
 // Comment out the executors you don't want to deploy
 const executors_to_deploy = {
     "ethereum": [
-        // USV2 - Args: Factory, Pool Init Code Hash
+        // USV2 - Args: Factory, Pool Init Code Hash, Fee BPS
         {
             exchange: "UniswapV2Executor", args: [
                 "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
-                "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+                "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f",
+                30
             ]
         },
-        // SUSHISWAP - Args: Factory, Pool Init Code Hash
+        // SUSHISWAP - Args: Factory, Pool Init Code Hash, Fee BPS, Fee BPS
         {
             exchange: "UniswapV2Executor", args: [
                 "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac",
-                "0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303"
+                "0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303",
+                30
             ]
         },
-        // PANCAKESWAP V2 - Args: Factory, Pool Init Code Hash
+        // PANCAKESWAP V2 - Args: Factory, Pool Init Code Hash, Fee BPS
         {
             exchange: "UniswapV2Executor", args: [
                 "0x1097053Fd2ea711dad45caCcc45EfF7548fCB362",
-                "0x57224589c67f3f30a6b0d7a1b54cf3153ab84563bc609ef41dfb34f8b2974d2d"
+                "0x57224589c67f3f30a6b0d7a1b54cf3153ab84563bc609ef41dfb34f8b2974d2d",
+                25
             ]
         },
         // USV3 -Args: Factory, Pool Init Code Hash
@@ -57,25 +60,28 @@ const executors_to_deploy = {
         }
     ],
     "base": [
-        // Args: Factory, Pool Init Code Hash
+        // Args: Factory, Pool Init Code Hash, Fee BPS
         {
             exchange: "UniswapV2Executor", args: [
                 "0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6",
-                "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+                "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f",
+                30
             ]
         },
-        // SUSHISWAP V2 - Args: Factory, Pool Init Code Hash
+        // SUSHISWAP V2 - Args: Factory, Pool Init Code Hash, Fee BPS
         {
             exchange: "UniswapV2Executor", args: [
                 "0x71524B4f93c58fcbF659783284E38825f0622859",
-                "0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303"
+                "0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303",
+                30
             ]
         },
-        // PANCAKESWAP V2 - Args: Factory, Pool Init Code Hash
+        // PANCAKESWAP V2 - Args: Factory, Pool Init Code Hash, Fee BPS
         {
             exchange: "UniswapV2Executor", args: [
                 "0x02a84c1b3BBD7401a5f7fa98a384EBC70bB5749E",
-                "0x57224589c67f3f30a6b0d7a1b54cf3153ab84563bc609ef41dfb34f8b2974d2d"
+                "0x57224589c67f3f30a6b0d7a1b54cf3153ab84563bc609ef41dfb34f8b2974d2d",
+                25
             ]
         },
         // USV3 - Args: Factory, Pool Init Code Hash
@@ -97,11 +103,12 @@ const executors_to_deploy = {
         {exchange: "BalancerV2Executor", args: []},
     ],
     "unichain": [
-        // Args: Factory, Pool Init Code Hash
+        // Args: Factory, Pool Init Code Hash, Fee BPS
         {
             exchange: "UniswapV2Executor", args: [
                 "0x1f98400000000000000000000000000000000002",
-                "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+                "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f",
+                30
             ]
         },
         // USV3 - Args: Factory, Pool Init Code Hash

--- a/foundry/src/executors/UniswapV2Executor.sol
+++ b/foundry/src/executors/UniswapV2Executor.sol
@@ -10,6 +10,7 @@ error UniswapV2Executor__InvalidDataLength();
 error UniswapV2Executor__InvalidTarget();
 error UniswapV2Executor__InvalidFactory();
 error UniswapV2Executor__InvalidInitCode();
+error UniswapV2Executor__InvalidFee();
 
 contract UniswapV2Executor is IExecutor, TokenTransfer {
     using SafeERC20 for IERC20;
@@ -17,8 +18,9 @@ contract UniswapV2Executor is IExecutor, TokenTransfer {
     address public immutable factory;
     bytes32 public immutable initCode;
     address private immutable self;
+    uint256 public immutable feeBps;
 
-    constructor(address _factory, bytes32 _initCode, address _permit2)
+    constructor(address _factory, bytes32 _initCode, address _permit2, uint256 _feeBps)
         TokenTransfer(_permit2)
     {
         if (_factory == address(0)) {
@@ -29,6 +31,10 @@ contract UniswapV2Executor is IExecutor, TokenTransfer {
         }
         factory = _factory;
         initCode = _initCode;
+        if (_feeBps > 10000) {
+            revert UniswapV2Executor__InvalidFee();
+        }
+        feeBps = _feeBps;
         self = address(this);
     }
 
@@ -100,9 +106,9 @@ contract UniswapV2Executor is IExecutor, TokenTransfer {
         }
 
         require(reserveIn > 0 && reserveOut > 0, "L");
-        uint256 amountInWithFee = amountIn * 997;
+        uint256 amountInWithFee = amountIn * (10000 - feeBps);
         uint256 numerator = amountInWithFee * uint256(reserveOut);
-        uint256 denominator = (uint256(reserveIn) * 1000) + amountInWithFee;
+        uint256 denominator = (uint256(reserveIn) * 10000) + amountInWithFee;
         amount = numerator / denominator;
     }
 

--- a/foundry/src/executors/UniswapV2Executor.sol
+++ b/foundry/src/executors/UniswapV2Executor.sol
@@ -31,7 +31,7 @@ contract UniswapV2Executor is IExecutor, TokenTransfer {
         }
         factory = _factory;
         initCode = _initCode;
-        if (_feeBps > 10000) {
+        if (_feeBps > 30) {
             revert UniswapV2Executor__InvalidFee();
         }
         feeBps = _feeBps;

--- a/foundry/src/executors/UniswapV2Executor.sol
+++ b/foundry/src/executors/UniswapV2Executor.sol
@@ -20,9 +20,12 @@ contract UniswapV2Executor is IExecutor, TokenTransfer {
     address private immutable self;
     uint256 public immutable feeBps;
 
-    constructor(address _factory, bytes32 _initCode, address _permit2, uint256 _feeBps)
-        TokenTransfer(_permit2)
-    {
+    constructor(
+        address _factory,
+        bytes32 _initCode,
+        address _permit2,
+        uint256 _feeBps
+    ) TokenTransfer(_permit2) {
         if (_factory == address(0)) {
             revert UniswapV2Executor__InvalidFactory();
         }

--- a/foundry/test/TychoRouterTestSetup.sol
+++ b/foundry/test/TychoRouterTestSetup.sol
@@ -99,7 +99,7 @@ contract TychoRouterTestSetup is Constants, Permit2TestHelper {
 
         IPoolManager poolManager = IPoolManager(poolManagerAddress);
         usv2Executor =
-            new UniswapV2Executor(factoryV2, initCodeV2, PERMIT2_ADDRESS);
+            new UniswapV2Executor(factoryV2, initCodeV2, PERMIT2_ADDRESS, 30);
         usv3Executor =
             new UniswapV3Executor(factoryV3, initCodeV3, PERMIT2_ADDRESS);
         usv4Executor = new UniswapV4Executor(poolManager, PERMIT2_ADDRESS);

--- a/foundry/test/executors/UniswapV2Executor.t.sol
+++ b/foundry/test/executors/UniswapV2Executor.t.sol
@@ -8,8 +8,8 @@ import {Constants} from "../Constants.sol";
 import {Permit2TestHelper} from "../Permit2TestHelper.sol";
 
 contract UniswapV2ExecutorExposed is UniswapV2Executor {
-    constructor(address _factory, bytes32 _initCode, address _permit2)
-        UniswapV2Executor(_factory, _initCode, _permit2)
+    constructor(address _factory, bytes32 _initCode, address _permit2, uint256 _feeBps)
+        UniswapV2Executor(_factory, _initCode, _permit2, _feeBps)
     {}
 
     function decodeParams(bytes calldata data)
@@ -63,17 +63,19 @@ contract UniswapV2ExecutorTest is Test, Constants, Permit2TestHelper {
         uint256 forkBlock = 17323404;
         vm.createSelectFork(vm.rpcUrl("mainnet"), forkBlock);
         uniswapV2Exposed = new UniswapV2ExecutorExposed(
-            USV2_FACTORY_ETHEREUM, USV2_POOL_CODE_INIT_HASH, PERMIT2_ADDRESS
+            USV2_FACTORY_ETHEREUM, USV2_POOL_CODE_INIT_HASH, PERMIT2_ADDRESS, 30
         );
         sushiswapV2Exposed = new UniswapV2ExecutorExposed(
             SUSHISWAPV2_FACTORY_ETHEREUM,
             SUSHIV2_POOL_CODE_INIT_HASH,
-            PERMIT2_ADDRESS
+            PERMIT2_ADDRESS,
+        30
         );
         pancakeswapV2Exposed = new UniswapV2ExecutorExposed(
             PANCAKESWAPV2_FACTORY_ETHEREUM,
             PANCAKEV2_POOL_CODE_INIT_HASH,
-            PERMIT2_ADDRESS
+            PERMIT2_ADDRESS,
+     25
         );
         permit2 = IAllowanceTransfer(PERMIT2_ADDRESS);
     }

--- a/foundry/test/executors/UniswapV2Executor.t.sol
+++ b/foundry/test/executors/UniswapV2Executor.t.sol
@@ -8,9 +8,12 @@ import {Constants} from "../Constants.sol";
 import {Permit2TestHelper} from "../Permit2TestHelper.sol";
 
 contract UniswapV2ExecutorExposed is UniswapV2Executor {
-    constructor(address _factory, bytes32 _initCode, address _permit2, uint256 _feeBps)
-        UniswapV2Executor(_factory, _initCode, _permit2, _feeBps)
-    {}
+    constructor(
+        address _factory,
+        bytes32 _initCode,
+        address _permit2,
+        uint256 _feeBps
+    ) UniswapV2Executor(_factory, _initCode, _permit2, _feeBps) {}
 
     function decodeParams(bytes calldata data)
         external
@@ -69,13 +72,13 @@ contract UniswapV2ExecutorTest is Test, Constants, Permit2TestHelper {
             SUSHISWAPV2_FACTORY_ETHEREUM,
             SUSHIV2_POOL_CODE_INIT_HASH,
             PERMIT2_ADDRESS,
-        30
+            30
         );
         pancakeswapV2Exposed = new UniswapV2ExecutorExposed(
             PANCAKESWAPV2_FACTORY_ETHEREUM,
             PANCAKEV2_POOL_CODE_INIT_HASH,
             PERMIT2_ADDRESS,
-     25
+            25
         );
         permit2 = IAllowanceTransfer(PERMIT2_ADDRESS);
     }


### PR DESCRIPTION
- This fee is not the same depending on the fork. For example, Pancake V2 uses a 0.25% fee, while the USV2 fee is 0.3%. We were wrongly hard-coding this fee to 0.3%.