### PR TITLE
feat: Make USV3 callback work with direct executor call

### DIFF
--- a/foundry/src/executors/UniswapV3Executor.sol
+++ b/foundry/src/executors/UniswapV3Executor.sol
@@ -129,13 +129,7 @@ contract UniswapV3Executor is IExecutor, ICallback, TokenTransfer {
         int256, /* amount1Delta */
         bytes calldata /* data */
     ) external {
-        uint256 dataOffset = 4 + 32 + 32 + 32; // Skip selector + 2 ints + data_offset
-        uint256 dataLength =
-            uint256(bytes32(msg.data[dataOffset:dataOffset + 32]));
-
-        bytes calldata fullData = msg.data[4:dataOffset + 32 + dataLength];
-
-        handleCallback(fullData);
+        handleCallback(msg.data);
     }
 
     function _decodeData(bytes calldata data)

--- a/foundry/test/executors/UniswapV3Executor.t.sol
+++ b/foundry/test/executors/UniswapV3Executor.t.sol
@@ -96,6 +96,29 @@ contract UniswapV3ExecutorTest is Test, Constants, Permit2TestHelper {
         );
     }
 
+    function testSwapIntegration() public {
+        uint256 amountIn = 10 ** 18;
+        deal(WETH_ADDR, address(uniswapV3Exposed), amountIn);
+
+        uint256 expAmountOut = 1205_128428842122129186; //Swap 1 WETH for 1205.12 DAI
+        bool zeroForOne = false;
+
+        bytes memory data = encodeUniswapV3Swap(
+            WETH_ADDR,
+            DAI_ADDR,
+            address(this),
+            DAI_WETH_USV3,
+            zeroForOne,
+            TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL
+        );
+
+        uint256 amountOut = uniswapV3Exposed.swap(amountIn, data);
+
+        assertGe(amountOut, expAmountOut);
+        assertEq(IERC20(WETH_ADDR).balanceOf(address(uniswapV3Exposed)), 0);
+        assertGe(IERC20(DAI_ADDR).balanceOf(address(this)), expAmountOut);
+    }
+
     function testDecodeParamsInvalidDataLength() public {
         bytes memory invalidParams =
             abi.encodePacked(WETH_ADDR, address(2), address(3));


### PR DESCRIPTION
- We have decided to now support calling our executors normally (without using delegatecalls) since they now support specifying token transfers.
- This was disabled for UniswapV3 in the past also because of data decoding issues. This seems to be the solution, though.