### PR TITLE
fix: Remove tload from executor

### DIFF
--- a/foundry/src/executors/UniswapV4Executor.sol
+++ b/foundry/src/executors/UniswapV4Executor.sol
@@ -203,8 +203,6 @@ contract UniswapV4Executor is
 
     /**
      * @dev Internal function to handle the unlock callback.
-     * The executor address is needed to perform the call. If the router is being used, the executor address is in
-     * transient storage. If it is not, then address(this) should be used.
      */
     function _unlockCallback(bytes calldata data)
         internal

--- a/foundry/src/executors/UniswapV4Executor.sol
+++ b/foundry/src/executors/UniswapV4Executor.sol
@@ -44,6 +44,7 @@ contract UniswapV4Executor is
     using TransientStateLibrary for IPoolManager;
 
     IPoolManager public immutable poolManager;
+    address private immutable _self;
 
     struct UniswapV4Pool {
         address intermediaryToken;
@@ -55,6 +56,7 @@ contract UniswapV4Executor is
         TokenTransfer(_permit2)
     {
         poolManager = _poolManager;
+        _self = address(this);
     }
 
     /**
@@ -204,18 +206,9 @@ contract UniswapV4Executor is
         internal
         returns (bytes memory)
     {
-        address executor;
-        // slither-disable-next-line assembly
-        assembly {
-            executor := tload(0)
-        }
-
-        if (executor == address(0)) {
-            executor = address(this);
-        }
         // here we expect to call either `swapExactInputSingle` or `swapExactInput`. See `swap` to see how we encode the selector and the calldata
         // slither-disable-next-line low-level-calls
-        (bool success, bytes memory returnData) = executor.delegatecall(data);
+        (bool success, bytes memory returnData) = _self.delegatecall(data);
         if (!success) {
             revert(
                 string(


### PR DESCRIPTION
- Store the executor address when deploying instead.
- We would like to keep all instances of tload and tstore within the callback mechanism of our main TychoRouter contract for security reasons and to prevent any unexpected behaviour
- This way it's easy to reason that UniswapV4Executor will only ever execute a delegatecall to itself. Before it could in theory execute a delegatecall to any address. One had to look at all occurences of tstore(0, x) to ensure the address was constrained.