### PR TITLE
feat: Sketch transfer refactor

### DIFF
--- a/foundry/src/executors/CurveExecutor.sol
+++ b/foundry/src/executors/CurveExecutor.sol
@@ -65,20 +65,10 @@ contract CurveExecutor is IExecutor, TokenTransfer {
             int128 i,
             int128 j,
             bool tokenApprovalNeeded,
-            TransferType transferType,
             address receiver
         ) = _decodeData(data);
 
-        _transfer(
-            tokenIn,
-            msg.sender,
-            // Receiver can never be the pool, since the pool expects funds in the router contract
-            // Thus, this call will only ever be used to transfer funds from the user into the router.
-            address(this),
-            amountIn,
-            transferType
-        );
-
+        // The protocol expects funds in the router contract
         if (tokenApprovalNeeded && tokenIn != nativeToken) {
             // slither-disable-next-line unused-return
             IERC20(tokenIn).forceApprove(address(pool), type(uint256).max);
@@ -134,7 +124,6 @@ contract CurveExecutor is IExecutor, TokenTransfer {
             int128 i,
             int128 j,
             bool tokenApprovalNeeded,
-            TransferType transferType,
             address receiver
         )
     {
@@ -145,8 +134,7 @@ contract CurveExecutor is IExecutor, TokenTransfer {
         i = int128(uint128(uint8(data[61])));
         j = int128(uint128(uint8(data[62])));
         tokenApprovalNeeded = data[63] != 0;
-        transferType = TransferType(uint8(data[64]));
-        receiver = address(bytes20(data[65:85]));
+        receiver = address(bytes20(data[64:84]));
     }
 
     receive() external payable {

--- a/foundry/src/executors/MaverickV2Executor.sol
+++ b/foundry/src/executors/MaverickV2Executor.sol
@@ -30,9 +30,9 @@ contract MaverickV2Executor is IExecutor, TokenTransfer {
         address target;
         address receiver;
         IERC20 tokenIn;
-        TransferType transferType;
+        bool transferNeeded;
 
-        (tokenIn, target, receiver, transferType) = _decodeData(data);
+        (tokenIn, target, receiver, transferNeeded) = _decodeData(data);
 
         _verifyPairAddress(target);
         IMaverickV2Pool pool = IMaverickV2Pool(target);
@@ -48,7 +48,7 @@ contract MaverickV2Executor is IExecutor, TokenTransfer {
         });
 
         _transfer(
-            address(tokenIn), msg.sender, target, givenAmount, transferType
+            address(tokenIn), target, givenAmount, transferNeeded
         );
         // slither-disable-next-line unused-return
         (, calculatedAmount) = pool.swap(receiver, swapParams, "");
@@ -61,7 +61,7 @@ contract MaverickV2Executor is IExecutor, TokenTransfer {
             IERC20 inToken,
             address target,
             address receiver,
-            TransferType transferType
+            bool transferNeeded
         )
     {
         if (data.length != 61) {
@@ -70,7 +70,7 @@ contract MaverickV2Executor is IExecutor, TokenTransfer {
         inToken = IERC20(address(bytes20(data[0:20])));
         target = address(bytes20(data[20:40]));
         receiver = address(bytes20(data[40:60]));
-        transferType = TransferType(uint8(data[60]));
+        transferNeeded = data[60] != 0;
     }
 
     function _verifyPairAddress(address target) internal view {

--- a/foundry/src/executors/TokenTransfer.sol
+++ b/foundry/src/executors/TokenTransfer.sol
@@ -11,7 +11,6 @@ contract TokenTransfer {
 
     function _transfer(
         address tokenIn,
-        address sender,
         address receiver,
         uint256 amount,
         bool transferNeeded

--- a/foundry/src/executors/TokenTransfer.sol
+++ b/foundry/src/executors/TokenTransfer.sol
@@ -3,68 +3,25 @@ pragma solidity ^0.8.26;
 
 import "@interfaces/IExecutor.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@permit2/src/interfaces/IAllowanceTransfer.sol";
 
 error TokenTransfer__AddressZero();
 
 contract TokenTransfer {
     using SafeERC20 for IERC20;
 
-    IAllowanceTransfer public immutable permit2;
-
-    enum TransferType {
-        // Assume funds are in the TychoRouter - transfer into the pool
-        TRANSFER_TO_PROTOCOL,
-        // Assume funds are in msg.sender's wallet - transferFrom into the pool
-        TRANSFER_FROM_TO_PROTOCOL,
-        // Assume funds are in msg.sender's wallet - permit2TransferFrom into the pool
-        TRANSFER_PERMIT2_TO_PROTOCOL,
-        // Assume funds are in msg.sender's wallet - but the pool requires it to be
-        // in the router contract when calling swap - transferFrom into the router
-        // contract
-        TRANSFER_FROM_TO_ROUTER,
-        // Assume funds are in msg.sender's wallet - but the pool requires it to be
-        // in the router contract when calling swap - transferFrom into the router
-        // contract using permit2
-        TRANSFER_PERMIT2_TO_ROUTER,
-        // Assume funds have already been transferred into the pool. Do nothing.
-        NONE
-    }
-
-    constructor(address _permit2) {
-        if (_permit2 == address(0)) {
-            revert TokenTransfer__AddressZero();
-        }
-        permit2 = IAllowanceTransfer(_permit2);
-    }
-
     function _transfer(
         address tokenIn,
         address sender,
         address receiver,
         uint256 amount,
-        TransferType transferType
+        bool transferNeeded
     ) internal {
-        if (transferType == TransferType.TRANSFER_TO_PROTOCOL) {
+        if (transferNeeded == true) {
             if (tokenIn == address(0)) {
                 payable(receiver).transfer(amount);
             } else {
                 IERC20(tokenIn).safeTransfer(receiver, amount);
             }
-        } else if (transferType == TransferType.TRANSFER_FROM_TO_PROTOCOL) {
-            // slither-disable-next-line arbitrary-send-erc20
-            IERC20(tokenIn).safeTransferFrom(sender, receiver, amount);
-        } else if (transferType == TransferType.TRANSFER_PERMIT2_TO_PROTOCOL) {
-            // Permit2.permit is already called from the TychoRouter
-            permit2.transferFrom(sender, receiver, uint160(amount), tokenIn);
-        } else if (transferType == TransferType.TRANSFER_FROM_TO_ROUTER) {
-            // slither-disable-next-line arbitrary-send-erc20
-            IERC20(tokenIn).safeTransferFrom(sender, address(this), amount);
-        } else if (transferType == TransferType.TRANSFER_PERMIT2_TO_ROUTER) {
-            // Permit2.permit is already called from the TychoRouter
-            permit2.transferFrom(
-                sender, address(this), uint160(amount), tokenIn
-            );
         }
     }
 }

--- a/foundry/src/executors/UniswapV2Executor.sol
+++ b/foundry/src/executors/UniswapV2Executor.sol
@@ -51,16 +51,16 @@ contract UniswapV2Executor is IExecutor, TokenTransfer {
         address target;
         address receiver;
         bool zeroForOne;
-        TransferType transferType;
+        bool transferNeeded;
 
-        (tokenIn, target, receiver, zeroForOne, transferType) =
+        (tokenIn, target, receiver, zeroForOne, transferNeeded) =
             _decodeData(data);
 
         _verifyPairAddress(target);
 
         calculatedAmount = _getAmountOut(target, givenAmount, zeroForOne);
         _transfer(
-            address(tokenIn), msg.sender, target, givenAmount, transferType
+            address(tokenIn), target, givenAmount, transferNeeded
         );
 
         IUniswapV2Pair pool = IUniswapV2Pair(target);
@@ -79,7 +79,7 @@ contract UniswapV2Executor is IExecutor, TokenTransfer {
             address target,
             address receiver,
             bool zeroForOne,
-            TransferType transferType
+            bool transferNeeded
         )
     {
         if (data.length != 62) {
@@ -89,7 +89,7 @@ contract UniswapV2Executor is IExecutor, TokenTransfer {
         target = address(bytes20(data[20:40]));
         receiver = address(bytes20(data[40:60]));
         zeroForOne = uint8(data[60]) > 0;
-        transferType = TransferType(uint8(data[61]));
+        transferNeeded = data[61] > 0;
     }
 
     function _getAmountOut(address target, uint256 amountIn, bool zeroForOne)

--- a/foundry/test/TychoRouterSplitSwap.t.sol
+++ b/foundry/test/TychoRouterSplitSwap.t.sol
@@ -8,7 +8,7 @@ import "./executors/UniswapV4Utils.sol";
 import {SafeCallback} from "@uniswap/v4-periphery/src/base/SafeCallback.sol";
 
 contract TychoRouterSplitSwapTest is TychoRouterTestSetup {
-    function _getSplitSwaps(bool permit2)
+    function _getSplitSwaps()
         private
         view
         returns (bytes[] memory)
@@ -19,10 +19,6 @@ contract TychoRouterSplitSwapTest is TychoRouterTestSetup {
         //          ->   WBTC  ->
         //       (univ2)     (univ2)
         bytes[] memory swaps = new bytes[](4);
-
-        TokenTransfer.TransferType inTransferType = permit2
-            ? TokenTransfer.TransferType.TRANSFER_PERMIT2_TO_PROTOCOL
-            : TokenTransfer.TransferType.TRANSFER_FROM_TO_PROTOCOL;
 
         // WETH -> WBTC (60%)
         swaps[0] = encodeSplitSwap(
@@ -35,7 +31,7 @@ contract TychoRouterSplitSwapTest is TychoRouterTestSetup {
                 WETH_WBTC_POOL,
                 tychoRouterAddr,
                 false,
-                inTransferType
+                false // transfer not needed -> transfer directly from user to pool
             )
         );
         // WBTC -> USDC
@@ -49,7 +45,7 @@ contract TychoRouterSplitSwapTest is TychoRouterTestSetup {
                 USDC_WBTC_POOL,
                 ALICE,
                 true,
-                TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL
+                true // transfer needed
             )
         );
         // WETH -> DAI
@@ -59,7 +55,7 @@ contract TychoRouterSplitSwapTest is TychoRouterTestSetup {
             uint24(0),
             address(usv2Executor),
             encodeUniswapV2Swap(
-                WETH_ADDR, WETH_DAI_POOL, tychoRouterAddr, false, inTransferType
+                WETH_ADDR, WETH_DAI_POOL, tychoRouterAddr, false,  false // transfer not needed -> transfer directly from user to pool
             )
         );
 
@@ -74,7 +70,7 @@ contract TychoRouterSplitSwapTest is TychoRouterTestSetup {
                 DAI_USDC_POOL,
                 ALICE,
                 true,
-                TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL
+                true // transfer needed
             )
         );
 

--- a/foundry/test/TychoRouterTestSetup.sol
+++ b/foundry/test/TychoRouterTestSetup.sol
@@ -185,10 +185,10 @@ contract TychoRouterTestSetup is Constants, Permit2TestHelper, TestUtils {
         address target,
         address receiver,
         bool zero2one,
-        TokenTransfer.TransferType transferType
+        bool transferNeeded
     ) internal pure returns (bytes memory) {
         return
-            abi.encodePacked(tokenIn, target, receiver, zero2one, transferType);
+            abi.encodePacked(tokenIn, target, receiver, zero2one, transferNeeded);
     }
 
     function encodeUniswapV3Swap(
@@ -197,7 +197,7 @@ contract TychoRouterTestSetup is Constants, Permit2TestHelper, TestUtils {
         address receiver,
         address target,
         bool zero2one,
-        TokenTransfer.TransferType transferType
+        bool transferNeeded
     ) internal view returns (bytes memory) {
         IUniswapV3Pool pool = IUniswapV3Pool(target);
         return abi.encodePacked(
@@ -207,7 +207,7 @@ contract TychoRouterTestSetup is Constants, Permit2TestHelper, TestUtils {
             receiver,
             target,
             zero2one,
-            transferType
+            transferNeeded
         );
     }
 }

--- a/foundry/test/executors/BalancerV2Executor.t.sol
+++ b/foundry/test/executors/BalancerV2Executor.t.sol
@@ -15,9 +15,7 @@ contract BalancerV2ExecutorExposed is BalancerV2Executor {
             IERC20 tokenIn,
             IERC20 tokenOut,
             bytes32 poolId,
-            address receiver,
-            bool needsApproval,
-            TransferType transferType
+            address receiver
         )
     {
         return _decodeData(data);
@@ -41,29 +39,16 @@ contract BalancerV2ExecutorTest is Constants, TestUtils {
 
     function testDecodeParams() public view {
         bytes memory params = abi.encodePacked(
-            WETH_ADDR,
-            BAL_ADDR,
-            WETH_BAL_POOL_ID,
-            address(2),
-            true,
-            TokenTransfer.TransferType.NONE
+            WETH_ADDR, BAL_ADDR, WETH_BAL_POOL_ID, address(2), true, false
         );
 
-        (
-            IERC20 tokenIn,
-            IERC20 tokenOut,
-            bytes32 poolId,
-            address receiver,
-            bool needsApproval,
-            TokenTransfer.TransferType transferType
-        ) = balancerV2Exposed.decodeParams(params);
+        (IERC20 tokenIn, IERC20 tokenOut, bytes32 poolId, address receiver,) =
+            balancerV2Exposed.decodeParams(params);
 
         assertEq(address(tokenIn), WETH_ADDR);
         assertEq(address(tokenOut), BAL_ADDR);
         assertEq(poolId, WETH_BAL_POOL_ID);
         assertEq(receiver, address(2));
-        assertEq(needsApproval, true);
-        assertEq(uint8(transferType), uint8(TokenTransfer.TransferType.NONE));
     }
 
     function testDecodeParamsInvalidDataLength() public {
@@ -77,12 +62,7 @@ contract BalancerV2ExecutorTest is Constants, TestUtils {
     function testSwap() public {
         uint256 amountIn = 10 ** 18;
         bytes memory protocolData = abi.encodePacked(
-            WETH_ADDR,
-            BAL_ADDR,
-            WETH_BAL_POOL_ID,
-            BOB,
-            true,
-            TokenTransfer.TransferType.NONE
+            WETH_ADDR, BAL_ADDR, WETH_BAL_POOL_ID, BOB, true, false
         );
 
         deal(WETH_ADDR, address(balancerV2Exposed), amountIn);
@@ -98,21 +78,13 @@ contract BalancerV2ExecutorTest is Constants, TestUtils {
     function testDecodeIntegration() public view {
         bytes memory protocolData =
             loadCallDataFromFile("test_encode_balancer_v2");
-        (
-            IERC20 tokenIn,
-            IERC20 tokenOut,
-            bytes32 poolId,
-            address receiver,
-            bool needsApproval,
-            TokenTransfer.TransferType transferType
-        ) = balancerV2Exposed.decodeParams(protocolData);
+        (IERC20 tokenIn, IERC20 tokenOut, bytes32 poolId, address receiver) =
+            balancerV2Exposed.decodeParams(protocolData);
 
         assertEq(address(tokenIn), WETH_ADDR);
         assertEq(address(tokenOut), BAL_ADDR);
         assertEq(poolId, WETH_BAL_POOL_ID);
         assertEq(receiver, BOB);
-        assertEq(needsApproval, true);
-        assertEq(uint8(transferType), uint8(TokenTransfer.TransferType.NONE));
     }
 
     function testSwapIntegration() public {

--- a/foundry/test/executors/CurveExecutor.t.sol
+++ b/foundry/test/executors/CurveExecutor.t.sol
@@ -37,7 +37,6 @@ contract CurveExecutorExposed is CurveExecutor {
             int128 i,
             int128 j,
             bool tokenApprovalNeeded,
-            TokenTransfer.TransferType transferType,
             address receiver
         )
     {
@@ -80,7 +79,6 @@ contract CurveExecutorTest is Test, Constants {
             int128 i,
             int128 j,
             bool tokenApprovalNeeded,
-            TokenTransfer.TransferType transferType,
             address receiver
         ) = curveExecutorExposed.decodeData(data);
 
@@ -91,7 +89,6 @@ contract CurveExecutorTest is Test, Constants {
         assertEq(i, 2);
         assertEq(j, 0);
         assertEq(tokenApprovalNeeded, true);
-        assertEq(uint8(transferType), uint8(TokenTransfer.TransferType.NONE));
         assertEq(receiver, ALICE);
     }
 

--- a/foundry/test/executors/EkuboExecutor.t.sol
+++ b/foundry/test/executors/EkuboExecutor.t.sol
@@ -45,7 +45,7 @@ contract EkuboExecutorTest is Constants, TestUtils {
         uint256 usdcBalanceBeforeExecutor = USDC.balanceOf(address(executor));
 
         bytes memory data = abi.encodePacked(
-            uint8(TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL), // transferType (transfer from executor to core)
+            true, // transferNeeded
             address(executor), // receiver
             NATIVE_TOKEN_ADDRESS, // tokenIn
             USDC_ADDR, // tokenOut
@@ -140,7 +140,7 @@ contract EkuboExecutorTest is Constants, TestUtils {
     // Same test case as in swap_encoder::tests::ekubo::test_encode_swap_multi
     function testMultiHopSwap() public {
         bytes memory data = abi.encodePacked(
-            uint8(TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL), // transferType
+            true, // transferNeeded
             address(executor), // receiver
             NATIVE_TOKEN_ADDRESS, // tokenIn
             USDC_ADDR, // tokenOut of 1st swap

--- a/foundry/test/executors/MaverickV2Executor.t.sol
+++ b/foundry/test/executors/MaverickV2Executor.t.sol
@@ -17,7 +17,7 @@ contract MaverickV2ExecutorExposed is MaverickV2Executor {
             IERC20 tokenIn,
             address target,
             address receiver,
-            TransferType transferType
+            bool transferNeeded
         )
     {
         return _decodeData(data);
@@ -43,23 +43,20 @@ contract MaverickV2ExecutorTest is TestUtils, Constants {
             GHO_ADDR,
             GHO_USDC_POOL,
             address(2),
-            TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL
+            true
         );
 
         (
             IERC20 tokenIn,
             address target,
             address receiver,
-            TokenTransfer.TransferType transferType
+            bool transferNeeded
         ) = maverickV2Exposed.decodeParams(params);
 
         assertEq(address(tokenIn), GHO_ADDR);
         assertEq(target, GHO_USDC_POOL);
         assertEq(receiver, address(2));
-        assertEq(
-            uint8(transferType),
-            uint8(TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL)
-        );
+        assertEq(transferNeeded, true);
     }
 
     function testDecodeParamsInvalidDataLength() public {
@@ -76,7 +73,7 @@ contract MaverickV2ExecutorTest is TestUtils, Constants {
             GHO_ADDR,
             GHO_USDC_POOL,
             BOB,
-            TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL
+            true
         );
 
         deal(GHO_ADDR, address(maverickV2Exposed), amountIn);
@@ -98,15 +95,14 @@ contract MaverickV2ExecutorTest is TestUtils, Constants {
             IERC20 tokenIn,
             address pool,
             address receiver,
-            TokenTransfer.TransferType transferType
+            bool transferNeeded
         ) = maverickV2Exposed.decodeParams(protocolData);
 
         assertEq(address(tokenIn), GHO_ADDR);
         assertEq(pool, GHO_USDC_POOL);
         assertEq(receiver, BOB);
         assertEq(
-            uint8(transferType),
-            uint8(TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL)
+            transferNeeded, true
         );
     }
 

--- a/foundry/test/executors/UniswapV2Executor.t.sol
+++ b/foundry/test/executors/UniswapV2Executor.t.sol
@@ -23,7 +23,7 @@ contract UniswapV2ExecutorExposed is UniswapV2Executor {
             address target,
             address receiver,
             bool zeroForOne,
-            TransferType transferType
+            bool transferNeeded
         )
     {
         return _decodeData(data);
@@ -97,7 +97,7 @@ contract UniswapV2ExecutorTest is Test, Constants, Permit2TestHelper {
             address target,
             address receiver,
             bool zeroForOne,
-            TokenTransfer.TransferType transferType
+            bool transferNeeded
         ) = uniswapV2Exposed.decodeParams(params);
 
         assertEq(address(tokenIn), WETH_ADDR);
@@ -105,8 +105,7 @@ contract UniswapV2ExecutorTest is Test, Constants, Permit2TestHelper {
         assertEq(receiver, address(3));
         assertEq(zeroForOne, false);
         assertEq(
-            uint8(TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL),
-            uint8(transferType)
+            transferNeeded, true
         );
     }
 
@@ -255,15 +254,14 @@ contract UniswapV2ExecutorTest is Test, Constants, Permit2TestHelper {
             address target,
             address receiver,
             bool zeroForOne,
-            TokenTransfer.TransferType transferType
+            bool transferNeeded
         ) = uniswapV2Exposed.decodeParams(protocolData);
 
         assertEq(address(tokenIn), WETH_ADDR);
         assertEq(target, 0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640);
         assertEq(receiver, 0x0000000000000000000000000000000000000001);
         assertEq(zeroForOne, false);
-        // TRANSFER = 0
-        assertEq(0, uint8(transferType));
+        assertEq(transferNeeded, true);
     }
 
     function testSwapIntegration() public {

--- a/foundry/test/executors/UniswapV3Executor.t.sol
+++ b/foundry/test/executors/UniswapV3Executor.t.sol
@@ -22,7 +22,7 @@ contract UniswapV3ExecutorExposed is UniswapV3Executor {
             address receiver,
             address target,
             bool zeroForOne,
-            TransferType transferType
+            bool transferNeeded
         )
     {
         return _decodeData(data);
@@ -81,7 +81,7 @@ contract UniswapV3ExecutorTest is Test, Constants, Permit2TestHelper {
             address receiver,
             address target,
             bool zeroForOne,
-            TokenTransfer.TransferType transferType
+            bool transferNeeded
         ) = uniswapV3Exposed.decodeData(data);
 
         assertEq(tokenIn, WETH_ADDR);
@@ -91,8 +91,7 @@ contract UniswapV3ExecutorTest is Test, Constants, Permit2TestHelper {
         assertEq(target, address(3));
         assertEq(zeroForOne, false);
         assertEq(
-            uint8(transferType),
-            uint8(TokenTransfer.TransferType.TRANSFER_TO_PROTOCOL)
+            transferNeeded, true
         );
     }
 
@@ -197,7 +196,7 @@ contract UniswapV3ExecutorTest is Test, Constants, Permit2TestHelper {
         address receiver,
         address target,
         bool zero2one,
-        TokenTransfer.TransferType transferType
+        bool transferNeeded
     ) internal view returns (bytes memory) {
         IUniswapV3Pool pool = IUniswapV3Pool(target);
         return abi.encodePacked(
@@ -207,7 +206,7 @@ contract UniswapV3ExecutorTest is Test, Constants, Permit2TestHelper {
             receiver,
             target,
             zero2one,
-            transferType
+            transferNeeded
         );
     }
 }

--- a/foundry/test/executors/UniswapV4Executor.t.sol
+++ b/foundry/test/executors/UniswapV4Executor.t.sol
@@ -22,7 +22,7 @@ contract UniswapV4ExecutorExposed is UniswapV4Executor {
             address tokenIn,
             address tokenOut,
             bool zeroForOne,
-            TokenTransfer.TransferType transferType,
+            bool transferNeeded,
             address receiver,
             UniswapV4Pool[] memory pools
         )
@@ -53,8 +53,7 @@ contract UniswapV4ExecutorTest is Constants, TestUtils {
         int24 tickSpacing1 = 60;
         uint24 pool2Fee = 1000;
         int24 tickSpacing2 = -10;
-        TokenTransfer.TransferType transferType =
-            TokenTransfer.TransferType.TRANSFER_FROM_TO_PROTOCOL;
+        bool transferNeeded = true;
 
         UniswapV4Executor.UniswapV4Pool[] memory pools =
             new UniswapV4Executor.UniswapV4Pool[](2);
@@ -70,14 +69,14 @@ contract UniswapV4ExecutorTest is Constants, TestUtils {
         });
 
         bytes memory data = UniswapV4Utils.encodeExactInput(
-            USDE_ADDR, USDT_ADDR, zeroForOne, transferType, ALICE, pools
+            USDE_ADDR, USDT_ADDR, zeroForOne, transferNeeded, ALICE, pools
         );
 
         (
             address tokenIn,
             address tokenOut,
             bool zeroForOneDecoded,
-            TokenTransfer.TransferType transferTypeDecoded,
+            bool transferNeededDecoded,
             address receiver,
             UniswapV4Executor.UniswapV4Pool[] memory decodedPools
         ) = uniswapV4Exposed.decodeData(data);
@@ -85,7 +84,7 @@ contract UniswapV4ExecutorTest is Constants, TestUtils {
         assertEq(tokenIn, USDE_ADDR);
         assertEq(tokenOut, USDT_ADDR);
         assertEq(zeroForOneDecoded, zeroForOne);
-        assertEq(uint8(transferTypeDecoded), uint8(transferType));
+        assertEq(transferNeededDecoded, transferNeeded);
         assertEq(receiver, ALICE);
         assertEq(decodedPools.length, 2);
         assertEq(decodedPools[0].intermediaryToken, USDT_ADDR);

--- a/foundry/test/executors/UniswapV4Utils.sol
+++ b/foundry/test/executors/UniswapV4Utils.sol
@@ -8,7 +8,7 @@ library UniswapV4Utils {
         address tokenIn,
         address tokenOut,
         bool zeroForOne,
-        UniswapV4Executor.TransferType transferType,
+        bool transferNeeded,
         address receiver,
         UniswapV4Executor.UniswapV4Pool[] memory pools
     ) public pure returns (bytes memory) {
@@ -24,7 +24,7 @@ library UniswapV4Utils {
         }
 
         return abi.encodePacked(
-            tokenIn, tokenOut, zeroForOne, transferType, receiver, encodedPools
+            tokenIn, tokenOut, zeroForOne, transferNeeded, receiver, encodedPools
         );
     }
 }

--- a/src/encoding/evm/strategy_encoder/transfer_optimizations.rs
+++ b/src/encoding/evm/strategy_encoder/transfer_optimizations.rs
@@ -39,6 +39,9 @@ impl TransferOptimization {
     }
 
     /// Returns the transfer method that should be used for the given swap and solution.
+    // TODO: Then this can be simplified to handle only the first swap
+    // and we make a new function for the other swaps that just figures out if the transfer is
+    // needed or not
     pub fn get_transfer_type(
         &self,
         swap: SwapGroup,


### PR DESCRIPTION
The issue is that the executors have "access to the user funds" unnecessarily from the TokenTransfer generalisation. The transfer types 
````
TRANSFER_FROM_TO_PROTOCOL,
TRANSFER_PERMIT2_TO_PROTOCOL,
TRANSFER_FROM_TO_ROUTER,
TRANSFER_PERMIT2_TO_ROUTER,
`````
are actually only meant to be used once per solution! so we could bring this logic back into the router. This is what I propose here, to split responsibilities:
- The router (single, sequential, split) will be responsible for getting the funds from the user and into the router/pool
- The executors only need to at most make a transfer from the router into the pool. So the data passed here can also be simplified to a simple bool.