### PR TITLE
feat: Plan for holding tokens in the router

### DIFF
--- a/foundry/src/BetterTychoRouter.sol
+++ b/foundry/src/BetterTychoRouter.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.26;
+
+import "../lib/IWETH.sol";
+import "../lib/bytes/LibPrefixLengthEncodedByteArray.sol";
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@permit2/src/interfaces/IAllowanceTransfer.sol";
+import "./Dispatcher.sol";
+import {LibSwap} from "../lib/LibSwap.sol";
+import {RestrictTransferFrom} from "./RestrictTransferFrom.sol";
+
+error TychoRouter__AddressZero();
+error TychoRouter__EmptySwaps();
+error TychoRouter__NegativeSlippage(uint256 amount, uint256 minAmount);
+error TychoRouter__AmountOutNotFullyReceived(
+    uint256 amountIn, uint256 amountConsumed
+);
+error TychoRouter__MessageValueMismatch(uint256 value, uint256 amount);
+error TychoRouter__InvalidDataLength();
+error TychoRouter__UndefinedMinAmountOut();
+
+contract TychoRouter is
+    AccessControl,
+    Dispatcher,
+    Pausable,
+    ReentrancyGuard,
+    RestrictTransferFrom
+{
+    using SafeERC20 for IERC20;
+    using LibPrefixLengthEncodedByteArray for bytes;
+    using LibSwap for bytes;
+
+    // this is to keep track of how much a user already inputted into the TychoRouter
+    mapping(address owner => mapping(address token => uint256 balance)) public
+        balanceOfUser;
+
+    constructor(address _permit2, address weth)
+        RestrictTransferFrom(_permit2)
+    {
+        if (_permit2 == address(0) || weth == address(0)) {
+            revert TychoRouter__AddressZero();
+        }
+        permit2 = IAllowanceTransfer(_permit2);
+    }
+
+    function unlock(address token) public {
+        uint256 currentBalance = _balanceOf(token, address(this));
+        _unlock(token, currentBalance);
+    }
+
+    function singleSwap(
+        uint256 amountIn,
+        address tokenIn,
+        address tokenOut,
+        uint256 minAmountOut,
+        bool wrapEth,
+        bool unwrapEth,
+        address receiver,
+        bool isTransferFromAllowed,
+        bytes calldata swapData
+    ) public payable whenNotPaused nonReentrant returns (uint256 amountOut) {
+        uint256 initialBalanceTokenOut = _balanceOf(tokenOut, receiver);
+        _tstoreTransferFromInfo(tokenIn, amountIn, false, isTransferFromAllowed);
+
+        // handle wrapping
+
+        (address executor, bytes calldata protocolData) =
+            swapData.decodeSingleSwap();
+
+        amountOut = _callSwapOnExecutor(executor, amountIn, protocolData);
+
+        if (amountOut < minAmountOut) {
+            revert TychoRouter__NegativeSlippage(amountOut, minAmountOut);
+        }
+
+        // handle unwrapping
+
+        uint256 currentBalanceTokenOut = _balanceOf(tokenOut, receiver);
+        if (tokenIn == tokenOut) {
+            // If it is an arbitrage, we need to remove the amountIn from the initial balance to get a correct userAmount
+            initialBalanceTokenOut -= amountIn;
+        }
+        uint256 userAmount = currentBalanceTokenOut - initialBalanceTokenOut;
+        if (userAmount != amountOut) {
+            revert TychoRouter__AmountOutNotFullyReceived(userAmount, amountOut);
+        }
+    }
+
+    function _balanceOf(address token, address owner)
+        internal
+        view
+        returns (uint256)
+    {
+        return
+            token == address(0) ? owner.balance : IERC20(token).balanceOf(owner);
+    }
+}

--- a/foundry/src/BetterTychoRouter.sol
+++ b/foundry/src/BetterTychoRouter.sol
@@ -49,9 +49,9 @@ contract TychoRouter is
         permit2 = IAllowanceTransfer(_permit2);
     }
 
-    function unlock(address token) public {
+    function unlock(address token, uint256 amount) public {
         uint256 currentBalance = _balanceOf(token, address(this));
-        _unlock(token, currentBalance);
+        _unlock(token, currentBalance, amount);
     }
 
     function singleSwap(
@@ -78,6 +78,8 @@ contract TychoRouter is
         if (amountOut < minAmountOut) {
             revert TychoRouter__NegativeSlippage(amountOut, minAmountOut);
         }
+
+        _is_everything_locked_at_the_end();
 
         // handle unwrapping
 

--- a/foundry/src/executors/CurveExecutor.sol
+++ b/foundry/src/executors/CurveExecutor.sol
@@ -108,7 +108,7 @@ contract CurveExecutor is IExecutor, RestrictTransferFrom {
         _maybe_lock(tokenIn, amountInRouter, amountIn);
 
         if (receiver != address(this)) {
-            _unlock(tokenOut, balanceBefore); // we trust that the curve pool
+            _unlock(tokenOut, balanceBefore, amountOut); // we trust that the curve pool will transfer the tokens back to the router
             _transfer(receiver, TransferType.Transfer, tokenOut, amountOut);
         }
         return amountOut;

--- a/foundry/src/executors/UniswapV2Executor.sol
+++ b/foundry/src/executors/UniswapV2Executor.sol
@@ -69,7 +69,7 @@ contract UniswapV2Executor is IExecutor, RestrictTransferFrom {
 
         // if the receiver is the router, set transient storage vars
         if (receiver == address(this)) {
-            _unlock(tokenOut, balanceBefore);
+            _unlock(tokenOut, balanceBefore, calculatedAmount);
         }
 
         IUniswapV2Pair pool = IUniswapV2Pair(target);


### PR DESCRIPTION
The goal is: to make the Router safe to hold tokens. 

For this I introduced two new transient storage values that hold uint256:
- `transferUnlocked`: the amount for this token that is unlocked
    - this is necessary because of split swaps. We might need to unlock/lock the same token multiple times, so we need to keep track of the amounts.
- `preSwapTokenBalance`: the balance of the router for this token before the swap
- `_UNLOCKED_TOKENS`: the number of tokens that are currently unlocked.

The slots for each are computed using the token address.

We have multiple scenarios where transfers happen:
- Token in transfer: the user's token in
    - normal allowances/permit2: this is under the router control.
        - before transferring we check the router balance for this token
        - after transferring and if the receiver was the router (it might have been a pool directly) => we unlock the router for this token and this amount. Unlocking means adding the amount to the current `transferUnlocked` variable, setting `preSwapTokenBalance` to the balance (if it's 0 previously) and adding 1 to the current _UNLOCKED_TOKENS.
    - user transfers tokens before calling the swap method
        - for this case, the user will have to call `unlock` on the Router themselves before transferring the funds. This way we know the router's balance prior to the transfer
- In between swaps token transfers: Sometimes between swaps (or in the first swap if it's a protocol that doesn't support optimizations) we also perform token transfers from the router funds. This happens in two scenarios:
    - At the end of the current swap, if the receiver is the router, then we need to unlock the router for token out so it can be used in the next swap (see Uniswap v2 Executor for example)
    -  When we call `_transfer` with `TransferType.Transfer`
        - In this case,  we need to call `_is_unlocked` before performing the actual transfer to make sure we won't use funds we are not supposed to. After the transfer we need to call `_maybe_lock`. `_maybe_lock` decreases the `transferUnlocked` with the current amount and if the unlocked amount is 0 then it will completely lock this token by setting preSwapTokenBalance to 0 and decrease one from _UNLOCKED_TOKENS.
        - For cases like curve and balancer v2, where the pool/vault takes the tokens directly from the router itself, we need to perform the `_is_unlocked` and `_maybe_lock` checks manually (see Curve Executor for example)

