### PR TITLE
feat: change version of github actions/checkout to v5

### DIFF
--- a/.github/workflows/evm-foundry-ci.yml
+++ b/.github/workflows/evm-foundry-ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       RPC_URL: ${{ secrets.ETH_RPC_URL }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
   publish-crate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -10,7 +10,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive

--- a/.github/workflows/tests-and-lints-template.yaml
+++ b/.github/workflows/tests-and-lints-template.yaml
@@ -48,7 +48,7 @@ jobs:
         run: sudo apt update && sudo apt install -y git
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -95,7 +95,7 @@ jobs:
         run: sudo apt update && sudo apt install -y git
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
[INFRA-158](https://propeller-heads.atlassian.net/browse/INFRA-158) - update ci/cd github **actions/checkout** to v5 due to upgrade ci/cd runner

[INFRA-158]: https://propeller-heads.atlassian.net/browse/INFRA-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ