### PR TITLE
refactor: use Bytes instead of String for addresses in encoders

### DIFF
--- a/src/encoding/evm/strategy_encoder/strategy_encoders.rs
+++ b/src/encoding/evm/strategy_encoder/strategy_encoders.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, str::FromStr};
+use std::collections::HashSet;
 
 use alloy::primitives::{aliases::U24, U8};
 use tycho_common::{models::Chain, Bytes};
@@ -149,11 +149,8 @@ impl StrategyEncoder for SingleSwapStrategyEncoder {
             }
         }
 
-        let swap_data = self.encode_swap_header(
-            Bytes::from_str(swap_encoder.executor_address())
-                .map_err(|_| EncodingError::FatalError("Invalid executor address".to_string()))?,
-            initial_protocol_data,
-        );
+        let swap_data =
+            self.encode_swap_header(swap_encoder.executor_address().clone(), initial_protocol_data);
         Ok(EncodedSolution {
             function_signature: self.function_signature.clone(),
             interacting_with: self.router_address.clone(),
@@ -321,12 +318,8 @@ impl StrategyEncoder for SequentialSwapStrategyEncoder {
                 }
             }
 
-            let swap_data = self.encode_swap_header(
-                Bytes::from_str(swap_encoder.executor_address()).map_err(|_| {
-                    EncodingError::FatalError("Invalid executor address".to_string())
-                })?,
-                initial_protocol_data,
-            );
+            let swap_data = self
+                .encode_swap_header(swap_encoder.executor_address().clone(), initial_protocol_data);
             swaps.push(swap_data);
         }
 
@@ -537,9 +530,7 @@ impl StrategyEncoder for SplitSwapStrategyEncoder {
                 get_token_position(&tokens, &grouped_swap.token_in)?,
                 get_token_position(&tokens, &grouped_swap.token_out)?,
                 percentage_to_uint24(grouped_swap.split),
-                Bytes::from_str(swap_encoder.executor_address()).map_err(|_| {
-                    EncodingError::FatalError("Invalid executor address".to_string())
-                })?,
+                swap_encoder.executor_address().clone(),
                 initial_protocol_data,
             );
             swaps.push(swap_data);

--- a/src/encoding/evm/swap_encoder/builder.rs
+++ b/src/encoding/evm/swap_encoder/builder.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use tycho_common::models::Chain;
+use tycho_common::{models::Chain, Bytes};
 
 use crate::encoding::{
     errors::EncodingError,
@@ -15,7 +15,7 @@ use crate::encoding::{
 /// Builds a `SwapEncoder` for the given protocol system and executor address.
 pub struct SwapEncoderBuilder {
     protocol_system: String,
-    executor_address: String,
+    executor_address: Bytes,
     chain: Chain,
     config: Option<HashMap<String, String>>,
 }
@@ -23,13 +23,13 @@ pub struct SwapEncoderBuilder {
 impl SwapEncoderBuilder {
     pub fn new(
         protocol_system: &str,
-        executor_address: &str,
+        executor_address: Bytes,
         chain: Chain,
         config: Option<HashMap<String, String>>,
     ) -> Self {
         SwapEncoderBuilder {
             protocol_system: protocol_system.to_string(),
-            executor_address: executor_address.to_string(),
+            executor_address,
             chain,
             config,
         }

--- a/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
+++ b/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
-use tycho_common::models::Chain;
+use tycho_common::{models::Chain, Bytes};
 
 use crate::encoding::{
     errors::EncodingError,
@@ -43,7 +43,12 @@ impl SwapEncoderRegistry {
         for (protocol, executor_address) in executors {
             let builder = SwapEncoderBuilder::new(
                 protocol,
-                executor_address,
+                Bytes::from_str(executor_address).map_err(|_| {
+                    EncodingError::FatalError(format!(
+                        "Invalid executor address for protocol {}",
+                        protocol
+                    ))
+                })?,
                 chain,
                 protocol_specific_config
                     .get(protocol)

--- a/src/encoding/evm/tycho_encoders.rs
+++ b/src/encoding/evm/tycho_encoders.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, str::FromStr};
+use std::collections::HashSet;
 
 use alloy::signers::local::PrivateKeySigner;
 use tycho_common::{models::Chain, Bytes};
@@ -352,12 +352,9 @@ impl TychoExecutorEncoder {
             initial_protocol_data.extend(ple_encode(grouped_protocol_data));
         }
 
-        let executor_address = Bytes::from_str(swap_encoder.executor_address())
-            .map_err(|_| EncodingError::FatalError("Invalid executor address".to_string()))?;
-
         Ok(EncodedSolution {
             swaps: initial_protocol_data,
-            interacting_with: executor_address,
+            interacting_with: swap_encoder.executor_address().clone(),
             permit: None,
             function_signature: "".to_string(),
             n_tokens: 0,

--- a/src/encoding/swap_encoder.rs
+++ b/src/encoding/swap_encoder.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use tycho_common::models::Chain;
+use tycho_common::{models::Chain, Bytes};
 
 use crate::encoding::{
     errors::EncodingError,
@@ -18,7 +18,7 @@ pub trait SwapEncoder: Sync + Send {
     /// * `config` - Additional configuration parameters for the encoder, like vault or registry
     ///   address
     fn new(
-        executor_address: String,
+        executor_address: Bytes,
         chain: Chain,
         config: Option<HashMap<String, String>>,
     ) -> Result<Self, EncodingError>
@@ -41,7 +41,7 @@ pub trait SwapEncoder: Sync + Send {
     ) -> Result<Vec<u8>, EncodingError>;
 
     /// Returns the address of the protocol-specific executor contract.
-    fn executor_address(&self) -> &str;
+    fn executor_address(&self) -> &Bytes;
 
     /// Creates a cloned instance of the swap encoder.
     ///


### PR DESCRIPTION
Store addresses used in encoders as Bytes instead of as Strings.