### PR TITLE
test: Sequential Euler swap with low balance

### DIFF
--- a/foundry/src/executors/MaverickV2Executor.sol
+++ b/foundry/src/executors/MaverickV2Executor.sol
@@ -42,13 +42,12 @@ contract MaverickV2Executor is IExecutor, RestrictTransferFrom {
 
         bool isTokenAIn = pool.tokenA() == tokenIn;
         int32 tickLimit = isTokenAIn ? type(int32).max : type(int32).min;
-        IMaverickV2Pool.SwapParams memory swapParams =
-            IMaverickV2Pool.SwapParams({
-                amount: givenAmount,
-                tokenAIn: isTokenAIn,
-                exactOutput: false,
-                tickLimit: tickLimit
-            });
+        IMaverickV2Pool.SwapParams memory swapParams = IMaverickV2Pool.SwapParams({
+            amount: givenAmount,
+            tokenAIn: isTokenAIn,
+            exactOutput: false,
+            tickLimit: tickLimit
+        });
 
         _transfer(target, transferType, address(tokenIn), givenAmount);
 


### PR DESCRIPTION
- We want to check pools using RLUSD because the pool manager doesn't hold much of this token, so we can't rely on pre-existing balance before the user makes a swap. We want to test a sequential swap here to check our grouping logic still works on Euler pools which store the balances on a proxy contract.