### PR TITLE
fix(angstrom): Block in place getting attestations

### DIFF
--- a/src/encoding/evm/swap_encoder/swap_encoders.rs
+++ b/src/encoding/evm/swap_encoder/swap_encoders.rs
@@ -292,7 +292,8 @@ impl SwapEncoder for UniswapV4SwapEncoder {
         let is_angstrom_hook = **hook_address == *self.angstrom_hook_address;
         let hook_data = if is_angstrom_hook {
             // Angstrom hook - obtain hook data from API
-            let attestations = Self::fetch_angstrom_attestations()?;
+            // Use block_in_place to avoid runtime dropping issues when called from async context
+            let attestations = tokio::task::block_in_place(|| Self::fetch_angstrom_attestations())?;
             Self::encode_angstrom_attestations(&attestations)?
         } else {
             // Regular hook - use user_data as normal


### PR DESCRIPTION
The encode_swap function is synchronous, but it calls fetch_angstrom_attestations() which uses reqwest::blocking::Client. The blocking client creates a Tokio runtime internally, and when this function is called from within an async context (as it is in the integration test), the runtime gets dropped causing a panic.
