### PR TITLE
feat: Use CREATE2 in deployment scripts

### DIFF
--- a/foundry/scripts/deploy-executors.js
+++ b/foundry/scripts/deploy-executors.js
@@ -220,18 +220,41 @@ async function main() {
     console.log(`Deploying with account: ${deployer.address}`);
     console.log(`Account balance: ${ethers.utils.formatEther(await deployer.getBalance())} ETH`);
 
+    // Deterministic Deployment Proxy
+    // More info: https://getfoundry.sh/guides/deterministic-deployments-using-create2/
+    const create2FactoryAddress = "0x4e59b44847b379578588920cA78FbF26c0B4956C";
+    console.log(`Using CREATE2 factory at: ${create2FactoryAddress}`);
+
     for (const executor of executors_to_deploy[network]) {
         const {exchange, args} = executor;
         const Executor = await ethers.getContractFactory(exchange);
-        const deployedExecutor = await Executor.deploy(...args);
-        await deployedExecutor.deployed();
-        console.log(`${exchange} deployed to: ${deployedExecutor.address}`);
+
+        // Get bytecode with constructor arguments
+        const deployTx = Executor.getDeployTransaction(...args);
+        const bytecode = deployTx.data;
+
+        // Use a salt that includes network and executor name
+        const salt = ethers.utils.id(`${exchange}-${network}`);
+
+        // Compute the address where the contract will be deployed
+        // CREATE2 address = keccak256(0xff ++ factory_address ++ salt ++ keccak256(bytecode))[12:]
+        const bytecodeHash = ethers.utils.keccak256(bytecode);
+        const computedAddress = ethers.utils.getCreate2Address(create2FactoryAddress, salt, bytecodeHash);
+        console.log(`${exchange} will be deployed to: ${computedAddress}`);
+
+        const deploymentData = ethers.utils.concat([salt, bytecode]);
+        const tx = await deployer.sendTransaction({
+            to: create2FactoryAddress,
+            data: deploymentData,
+        });
+        await tx.wait();
+        console.log(`${exchange} deployed to: ${computedAddress}`);
 
         // Verify on Tenderly
         try {
             await hre.tenderly.verify({
                 name: exchange,
-                address: deployedExecutor.address,
+                address: computedAddress,
             });
             console.log("Contract verified successfully on Tenderly");
         } catch (error) {
@@ -243,7 +266,7 @@ async function main() {
         // Verify on Etherscan
         try {
             await hre.run("verify:verify", {
-                address: deployedExecutor.address,
+                address: computedAddress,
                 constructorArguments: args,
             });
             console.log(`${exchange} verified successfully on blockchain explorer!`);


### PR DESCRIPTION
CREATE doesn’t include the code hash in the address computation, so now CurveExecutor on Unichain has the same address as UniswapV3Executor on Base which can be confusing. 

Furthermore, our scripts were broken since the `to` address was not properly found after deployment (failing in the dungeon of hardhat - out of our control), making it look like our transaction failed when it was really passing. Now, the scripts are running fine without this same problem.

We now use an existing well-known create2 factory contract mentioned in the foundry docs. The source code for that factory contract is here: https://github.com/Arachnid/deterministic-deployment-proxy

Why this factory is necessary: When you send a transaction with bytecode but no to address, the EVM automatically uses CREATE, whereas CREATE2 requires an explicit opcode call with a salt parameter that can only be executed from within contract code as opposed to by using Javascript/Hardhat.

I've tested that the script works fine by deploying a UniswapV2Executor [here](https://etherscan.io/address/0x2B9faB7B44f42B90ED5BA963A0Da2C20bB4311B7#code). It successfully went through the whole deployment/verification pipeline without manual intervention - very smooth.