### PR TITLE
feat: add timelock for new executors

### DIFF
--- a/foundry/src/Dispatcher.sol
+++ b/foundry/src/Dispatcher.sol
@@ -22,7 +22,7 @@ error Dispatcher__InvalidDataLength();
  */
 contract Dispatcher {
     struct ExecutorData {
-        uint256 activationBlock;
+        uint64 activationBlock;
         bool approved;
     }
 
@@ -32,8 +32,6 @@ contract Dispatcher {
     uint256 private constant _CURRENTLY_SWAPPING_EXECUTOR_SLOT =
         0x098a7a3b47801589e8cdf9ec791b93ad44273246946c32ef1fc4dbe45390c80e;
 
-    uint256 private constant _BLOCKS_TO_DELAY_FOR_NEW_EXECUTOR = 50400; // ~1 week
-
     event ExecutorSet(address indexed executor);
     event ExecutorRemoved(address indexed executor);
 
@@ -42,15 +40,15 @@ contract Dispatcher {
      *  contract.
      * @param target address of the executor contract
      */
-    function _setExecutor(address target) internal {
+    function _setExecutor(address target, uint64 block_to_delay_activation)
+        internal
+    {
         if (target.code.length == 0) {
             revert Dispatcher__NonContractExecutor();
         }
 
         executorData[target] = ExecutorData({
-            activationBlock: uint64(
-                block.number + _BLOCKS_TO_DELAY_FOR_NEW_EXECUTOR
-            ),
+            activationBlock: uint64(block.number + block_to_delay_activation),
             approved: true
         });
         emit ExecutorSet(target);

--- a/foundry/src/Dispatcher.sol
+++ b/foundry/src/Dispatcher.sol
@@ -73,13 +73,13 @@ contract Dispatcher {
         uint256 amount,
         bytes calldata data
     ) internal returns (uint256 calculatedAmount) {
-        ExecutorData memory d = executorData[executor];
+        ExecutorData memory executorInfo = executorData[executor];
 
-        if (!d.approved) {
+        if (!executorInfo.approved) {
             revert Dispatcher__UnapprovedExecutor(executor);
         }
 
-        if (block.number < d.activationBlock) {
+        if (block.number < executorInfo.activationBlock) {
             revert Dispatcher__ExecutorIsTimelocked(executor);
         }
 
@@ -120,9 +120,9 @@ contract Dispatcher {
             executor := tload(_CURRENTLY_SWAPPING_EXECUTOR_SLOT)
         }
 
-        ExecutorData memory d = executorData[executor];
+        ExecutorData memory executorInfo = executorData[executor];
 
-        if (!d.approved) {
+        if (!executorInfo.approved) {
             revert Dispatcher__UnapprovedExecutor(executor);
         }
 

--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -89,6 +89,15 @@ contract TychoRouter is
     bytes32 public constant FUND_RESCUER_ROLE =
         0x912e45d663a6f4cc1d0491d8f046e06c616f40352565ea1cdb86a0e1aaefa41b;
 
+    function _blocksToDelayForNewExecutor()
+        internal
+        view
+        virtual
+        returns (uint64)
+    {
+        return 50400; // ~1 week
+    }
+
     event Withdrawal(
         address indexed token, uint256 amount, address indexed receiver
     );
@@ -726,7 +735,7 @@ contract TychoRouter is
         onlyRole(EXECUTOR_SETTER_ROLE)
     {
         for (uint256 i = 0; i < targets.length; i++) {
-            _setExecutor(targets[i]);
+            _setExecutor(targets[i], _blocksToDelayForNewExecutor());
         }
     }
 

--- a/foundry/test/Dispatcher.t.sol
+++ b/foundry/test/Dispatcher.t.sol
@@ -17,7 +17,7 @@ contract DispatcherExposed is Dispatcher {
         _setExecutor(target, 50400);
     }
 
-    function exposedsetExecutorImmediately(address target) external {
+    function exposedSetExecutorImmediately(address target) external {
         _setExecutor(target, 0);
     }
 
@@ -119,7 +119,7 @@ contract DispatcherTest is Constants {
         // Thus, we chose a previously-deployed Hashflow executor for simplicity. To
         // change this test, we can find any of our transactions that succeeded, and
         // obtain the calldata passed to the executor via Tenderly.
-        dispatcherExposed.exposedsetExecutorImmediately(
+        dispatcherExposed.exposedSetExecutorImmediately(
             address(0xe592557AB9F4A75D992283fD6066312FF013ba3d)
         );
         bytes memory data =
@@ -143,7 +143,7 @@ contract DispatcherTest is Constants {
         // Thus, we chose a previously-deployed Hashflow executor for simplicity. To
         // change this test, we can find any of our transactions that succeeded, and
         // obtain the calldata passed to the executor via Tenderly.
-        dispatcherExposed.exposedsetExecutorImmediately(
+        dispatcherExposed.exposedSetExecutorImmediately(
             address(0xe592557AB9F4A75D992283fD6066312FF013ba3d)
         );
         bytes memory data =

--- a/foundry/test/Dispatcher.t.sol
+++ b/foundry/test/Dispatcher.t.sol
@@ -59,12 +59,11 @@ contract DispatcherTest is Constants {
         emit ExecutorRemoved(DUMMY);
         dispatcherExposed.exposedRemoveExecutor(DUMMY);
 
-        // Assert: mapping stores a struct, so check the struct fields
         (uint64 activationBlock, bool approved) =
             dispatcherExposed.executorData(DUMMY);
 
         assertEq(approved, false);
-        assertEq(activationBlock, 0); // `delete` zeroes the whole struct
+        assertEq(activationBlock, 0);
     }
 
     function testRemoveUnSetExecutor() public {

--- a/foundry/test/Dispatcher.t.sol
+++ b/foundry/test/Dispatcher.t.sol
@@ -14,7 +14,11 @@ contract DispatcherExposed is Dispatcher {
     }
 
     function exposedSetExecutor(address target) external {
-        _setExecutor(target);
+        _setExecutor(target, 50400);
+    }
+
+    function setExecutorImmediately(address target) external {
+        _setExecutor(target, 0);
     }
 
     function exposedRemoveExecutor(address target) external {
@@ -41,7 +45,11 @@ contract DispatcherTest is Constants {
         // Define the event we expect to be emitted at the next step
         emit ExecutorSet(DUMMY);
         dispatcherExposed.exposedSetExecutor(DUMMY);
-        assert(dispatcherExposed.executors(DUMMY) == true);
+        (uint64 activationBlock, bool approved) =
+            dispatcherExposed.executorData(DUMMY);
+
+        assert(approved == true);
+        assert(activationBlock > 0);
     }
 
     function testRemoveExecutor() public {
@@ -50,12 +58,21 @@ contract DispatcherTest is Constants {
         // Define the event we expect to be emitted at the next step
         emit ExecutorRemoved(DUMMY);
         dispatcherExposed.exposedRemoveExecutor(DUMMY);
-        assert(dispatcherExposed.executors(DUMMY) == false);
+
+        // Assert: mapping stores a struct, so check the struct fields
+        (uint64 activationBlock, bool approved) =
+            dispatcherExposed.executorData(DUMMY);
+
+        assertEq(approved, false);
+        assertEq(activationBlock, 0); // `delete` zeroes the whole struct
     }
 
     function testRemoveUnSetExecutor() public {
         dispatcherExposed.exposedRemoveExecutor(BOB);
-        assert(dispatcherExposed.executors(BOB) == false);
+        (uint64 activationBlock, bool approved) =
+            dispatcherExposed.executorData(BOB);
+        assertEq(approved, false);
+        assertEq(activationBlock, 0);
     }
 
     function testSetExecutorNonContract() public {
@@ -63,6 +80,34 @@ contract DispatcherTest is Constants {
             abi.encodeWithSelector(Dispatcher__NonContractExecutor.selector)
         );
         dispatcherExposed.exposedSetExecutor(BOB);
+    }
+
+    function testCallTimelockedExecutor() public {
+        // Test case taken from existing transaction
+        // 0x755d603962b30f416cf3eefae8d55204d6ffdf746465b2a94aca216faab63804
+        // For this test, we can use any executor and any calldata that we know works
+        // for this executor. We don't care about which calldata/executor, since we are
+        // only testing the functionality of the delegatecall and not the inner
+        // workings of the executor.
+        // Thus, we chose a previously-deployed Hashflow executor for simplicity. To
+        // change this test, we can find any of our transactions that succeeded, and
+        // obtain the calldata passed to the executor via Tenderly.
+
+        address executor = 0xe592557AB9F4A75D992283fD6066312FF013ba3d;
+        dispatcherExposed.exposedSetExecutor(executor);
+        bytes memory data =
+            hex"5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72fc8c39af7983bf329086de522229a7be5fc4e41cc51c72848c68a965f66fa7a88855f9f7784502a7f2606beffe61000613d6a25b5bfef4cd7652aa94777d4a46b39f2e206411280a12c9344b769ff1066c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000000000000000000000000000d02ab486cedc0000000000000000000000000000000000000000000000000000000000082ec8ad1b0000000000000000000000000000000000000000000000000000000066d7b65800000000000000000000000000000000000000000000000000000191ba9f843c125000064000640000d52de09955f0ffffffffffffff00225c389e595fe9000001fcc910754b349f821e4bb5d8444822a63920be943aba6f1b31ee14ef0fc6840b6d28d604e04a78834b668dba24a6c082ffb901e4fffa9600649e8d991af593c81c";
+        uint256 givenAmount = 15 ether;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Dispatcher__ExecutorIsTimelocked.selector, executor
+            )
+        );
+
+        dispatcherExposed.exposedCallExecutor(
+            0xe592557AB9F4A75D992283fD6066312FF013ba3d, givenAmount, data
+        );
     }
 
     function testCallExecutor() public {
@@ -75,7 +120,7 @@ contract DispatcherTest is Constants {
         // Thus, we chose a previously-deployed Hashflow executor for simplicity. To
         // change this test, we can find any of our transactions that succeeded, and
         // obtain the calldata passed to the executor via Tenderly.
-        dispatcherExposed.exposedSetExecutor(
+        dispatcherExposed.setExecutorImmediately(
             address(0xe592557AB9F4A75D992283fD6066312FF013ba3d)
         );
         bytes memory data =
@@ -99,7 +144,7 @@ contract DispatcherTest is Constants {
         // Thus, we chose a previously-deployed Hashflow executor for simplicity. To
         // change this test, we can find any of our transactions that succeeded, and
         // obtain the calldata passed to the executor via Tenderly.
-        dispatcherExposed.exposedSetExecutor(
+        dispatcherExposed.setExecutorImmediately(
             address(0xe592557AB9F4A75D992283fD6066312FF013ba3d)
         );
         bytes memory data =

--- a/foundry/test/Dispatcher.t.sol
+++ b/foundry/test/Dispatcher.t.sol
@@ -17,7 +17,7 @@ contract DispatcherExposed is Dispatcher {
         _setExecutor(target, 50400);
     }
 
-    function setExecutorImmediately(address target) external {
+    function exposedsetExecutorImmediately(address target) external {
         _setExecutor(target, 0);
     }
 
@@ -120,7 +120,7 @@ contract DispatcherTest is Constants {
         // Thus, we chose a previously-deployed Hashflow executor for simplicity. To
         // change this test, we can find any of our transactions that succeeded, and
         // obtain the calldata passed to the executor via Tenderly.
-        dispatcherExposed.setExecutorImmediately(
+        dispatcherExposed.exposedsetExecutorImmediately(
             address(0xe592557AB9F4A75D992283fD6066312FF013ba3d)
         );
         bytes memory data =
@@ -144,7 +144,7 @@ contract DispatcherTest is Constants {
         // Thus, we chose a previously-deployed Hashflow executor for simplicity. To
         // change this test, we can find any of our transactions that succeeded, and
         // obtain the calldata passed to the executor via Tenderly.
-        dispatcherExposed.setExecutorImmediately(
+        dispatcherExposed.exposedsetExecutorImmediately(
             address(0xe592557AB9F4A75D992283fD6066312FF013ba3d)
         );
         bytes memory data =

--- a/foundry/test/TychoRouter.t.sol
+++ b/foundry/test/TychoRouter.t.sol
@@ -67,7 +67,7 @@ contract TychoRouterTest is TychoRouterTestSetup {
         tychoRouter.removeExecutor(BOB);
     }
 
-    function testsetExecutorsForTestMissingSetterRole() public {
+    function testSetExecutorsForTestMissingSetterRole() public {
         vm.expectRevert();
         address[] memory executors = new address[](1);
         executors[0] = DUMMY;

--- a/foundry/test/TychoRouter.t.sol
+++ b/foundry/test/TychoRouter.t.sol
@@ -17,14 +17,17 @@ contract TychoRouterTest is TychoRouterTestSetup {
         address indexed token, uint256 amount, address indexed receiver
     );
 
-    function testSetExecutorsValidRole() public {
+    function testsetExecutorsForTestValidRole() public {
         // Set single executor
         address[] memory executors = new address[](1);
         executors[0] = DUMMY;
         vm.startPrank(EXECUTOR_SETTER);
         tychoRouter.setExecutors(executors);
         vm.stopPrank();
-        assert(tychoRouter.executors(DUMMY) == true);
+        (uint64 activationBlock, bool approved) =
+            tychoRouter.executorData(DUMMY);
+        assertEq(approved, true);
+        assertGt(activationBlock, 0);
 
         // Set multiple executors
         address[] memory executors2 = new address[](2);
@@ -33,8 +36,16 @@ contract TychoRouterTest is TychoRouterTestSetup {
         vm.startPrank(EXECUTOR_SETTER);
         tychoRouter.setExecutors(executors2);
         vm.stopPrank();
-        assert(tychoRouter.executors(DUMMY2) == true);
-        assert(tychoRouter.executors(DUMMY3) == true);
+
+        (uint64 activationBlock2, bool approved2) =
+            tychoRouter.executorData(DUMMY2);
+        assertEq(approved2, true);
+        assertGt(activationBlock2, 0);
+
+        (uint64 activationBlock3, bool approved3) =
+            tychoRouter.executorData(DUMMY3);
+        assertEq(approved3, true);
+        assertGt(activationBlock3, 0);
     }
 
     function testRemoveExecutorValidRole() public {
@@ -44,7 +55,11 @@ contract TychoRouterTest is TychoRouterTestSetup {
         tychoRouter.setExecutors(executors);
         tychoRouter.removeExecutor(DUMMY);
         vm.stopPrank();
-        assert(tychoRouter.executors(DUMMY) == false);
+
+        (uint64 activationBlock, bool approved) =
+            tychoRouter.executorData(DUMMY);
+        assertEq(approved, false);
+        assertEq(activationBlock, 0);
     }
 
     function testRemoveExecutorMissingSetterRole() public {
@@ -52,7 +67,7 @@ contract TychoRouterTest is TychoRouterTestSetup {
         tychoRouter.removeExecutor(BOB);
     }
 
-    function testSetExecutorsMissingSetterRole() public {
+    function testsetExecutorsForTestMissingSetterRole() public {
         vm.expectRevert();
         address[] memory executors = new address[](1);
         executors[0] = DUMMY;

--- a/foundry/test/TychoRouterTestSetup.sol
+++ b/foundry/test/TychoRouterTestSetup.sol
@@ -32,6 +32,15 @@ import "@src/TychoRouter.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 
 contract TychoRouterExposed is TychoRouter {
+    function _blocksToDelayForNewExecutor()
+        internal
+        view
+        override
+        returns (uint64)
+    {
+        return 0;
+    }
+
     constructor(address _permit2, address weth) TychoRouter(_permit2, weth) {}
 
     function wrapETH(uint256 amount) external payable {


### PR DESCRIPTION
In this PR:
- a timelock for newly deployed contracts introduced
- _setExecutors updated with an additional parameter to bypass the timelock in test scenarios
- gas measured using `forge test --match-test testSetValidExecutor --gas-report`

Gas change
exposedSetExecutor: 47,661 → 47,890 gas (+229)
Executor read: 2461 → 2526 gas (+65)
