### PR TITLE
feat(sdk notify): Wait for cargo release, not just github publish

### DIFF
--- a/.github/workflows/notify-sdk.yaml
+++ b/.github/workflows/notify-sdk.yaml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release' }}
     steps:
       - name: Wait for crates.io propagation
-        run: sleep 30
+        run: sleep 60
 
       - name: Get latest release tag
         id: get_tag

--- a/.github/workflows/notify-sdk.yaml
+++ b/.github/workflows/notify-sdk.yaml
@@ -1,22 +1,37 @@
 name: Notify SDK of new release
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
 
 jobs:
   notify-sdk:
     name: Trigger SDK update workflow
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release' }}
     steps:
+      - name: Wait for crates.io propagation
+        run: sleep 30
+
+      - name: Get latest release tag
+        id: get_tag
+        run: |
+          TAG=$(curl -s -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/releases/latest | \
+            jq -r .tag_name)
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Latest release tag: $TAG"
+
       - name: Trigger tycho-protocol-sdk update workflow
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.SDK_REPO_DISPATCH_TOKEN }}" \
             https://api.github.com/repos/propeller-heads/tycho-protocol-sdk/dispatches \
-            -d '{"event_type":"tycho-execution-release","client_payload":{"version":"${{ github.event.release.tag_name }}"}}'
+            -d '{"event_type":"tycho-execution-release","client_payload":{"version":"${{ steps.get_tag.outputs.tag }}"}}'
 
       - name: Log notification
         run: |
-          echo "Notified tycho-protocol-sdk of release ${{ github.event.release.tag_name }}"
+          echo "Notified tycho-protocol-sdk of release ${{ steps.get_tag.outputs.tag }}"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Tycho Execution makes it easy to trade on different DEXs by handling the complex
 custom code for each DEX, you get a simple, ready-to-use tool that generates the necessary data to execute trades. It's
 designed to be safe, straightforward, and quick to set up, so anyone can start trading without extra effort.
 
-For complete documentation, see Tycho docs [here](https://docs.propellerheads.xyz/tycho/for-solvers/execution).
+For complete documentation, see Tycho docs [here](https://docs.propellerheads.
+xyz/tycho/for-solvers/execution). 
 
 ## Examples
 


### PR DESCRIPTION
- We were sending the event before it was published to crates, which was problematic because tycho-protocol-sdk then attempted to pull from crates.
- About getting the latest tag: when you trigger on workflow_run, you DON'T have access to the release event context anymore. The workflow_run event only tells you "the Release workflow completed" - it doesn't include the release details. For this reason, we need to add another API call here to get the latest tag.