### PR TITLE
feat: add Alien Base V3 encoder for Base

### DIFF
--- a/config/executor_addresses.json
+++ b/config/executor_addresses.json
@@ -24,7 +24,8 @@
     "pancakeswap_v3": "0x21A97f2Aa8D9AE7144BfD080266Ee87cC2369656",
     "uniswap_v4": "0x8a3520889fE0bbF9E1F4a9724C27d8D6Ed9f0e29",
     "rfq:bebop": "0x489A3f531dA3873D6585BF3f8E0dEE48CAC6F7BC",
-    "aerodrome_slipstreams": "0x772f58A21a1E64c5677cDf16630205264caD2b6A"
+    "aerodrome_slipstreams": "0x772f58A21a1E64c5677cDf16630205264caD2b6A",
+    "alienbase_v3": "0x647bffbf8bd72bf6341ecba8b0279e090313a40d"
   },
   "unichain": {
     "uniswap_v2": "0x00C1b81e3C8f6347E69e2DDb90454798A6Be975E",

--- a/src/encoding/evm/constants.rs
+++ b/src/encoding/evm/constants.rs
@@ -54,6 +54,7 @@ pub static CALLBACK_CONSTRAINED_PROTOCOLS: LazyLock<HashSet<&'static str>> = Laz
     let mut set = HashSet::new();
     set.insert("uniswap_v3");
     set.insert("pancakeswap_v3");
+    set.insert("alienbase_v3");
     set.insert("uniswap_v4");
     set.insert("uniswap_v4_hooks");
     set.insert("ekubo_v2");

--- a/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
+++ b/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
@@ -109,7 +109,7 @@ impl SwapEncoderRegistry {
             "uniswap_v3" => {
                 Ok(Box::new(UniswapV3SwapEncoder::new(executor_address, self.chain, config)?))
             }
-            "pancakeswap_v3" => {
+            "pancakeswap_v3" | "alienbase_v3" => {
                 Ok(Box::new(UniswapV3SwapEncoder::new(executor_address, self.chain, config)?))
             }
             "uniswap_v4" => {

--- a/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
+++ b/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
@@ -109,6 +109,7 @@ impl SwapEncoderRegistry {
             "uniswap_v3" => {
                 Ok(Box::new(UniswapV3SwapEncoder::new(executor_address, self.chain, config)?))
             }
+            // Stock Uniswap V3 forks with identical swap encoding and callback pattern.
             "pancakeswap_v3" | "alienbase_v3" => {
                 Ok(Box::new(UniswapV3SwapEncoder::new(executor_address, self.chain, config)?))
             }


### PR DESCRIPTION
## Summary
- Register `alienbase_v3` protocol system with `UniswapV3SwapEncoder` in the encoder registry
- Add executor address for `alienbase_v3` on Base chain (reuses existing V3 executor `0x647bffbf8bd72bf6341ecba8b0279e090313a40d`)
- Alien Base V3 uses stock Uniswap V3 core contracts, so no new encoder or executor needed

## Changes
- `swap_encoder_registry.rs`: Add `"alienbase_v3"` to the `pancakeswap_v3` match arm (both are V3 forks)
- `executor_addresses.json`: Add `alienbase_v3` entry for `base` chain

## Verification
- All 148 tests pass (3 ignored)
- `cargo check` and `cargo clippy` clean
- Differential testing confirms identical swap math to Uniswap V3 (0-2 wei rounding)

## Related PRs
- tycho-protocol-sdk: propeller-heads/tycho-protocol-sdk (feat/alienbase-v3) - substreams config

## Test plan
- [x] `cargo check` passes
- [x] All unit tests pass (148 pass, 3 ignored)
- [x] Differential swap verification on Base (WETH/USDC: exact match, ALB/WETH: 2 wei)

🤖 Generated with [Claude Code](https://claude.com/claude-code)