### PR TITLE
fix: Use PR author instead of merged_by for release author

### DIFF
--- a/.github/workflows/notify-sdk.yaml
+++ b/.github/workflows/notify-sdk.yaml
@@ -49,7 +49,7 @@ jobs:
 
           AUTHOR=""
           if [ -n "$PARENT_SHA" ]; then
-            AUTHOR=$(gh api "repos/$REPO/commits/$PARENT_SHA/pulls" --jq '.[0].merged_by.login // empty' 2>/dev/null || echo "")
+            AUTHOR=$(gh api "repos/$REPO/commits/$PARENT_SHA/pulls" --jq '.[0].user.login // empty' 2>/dev/null || echo "")
           fi
 
           echo "author=$AUTHOR" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The commits/{sha}/pulls endpoint doesn't include merged_by in its response. Use user.login (the PR author) instead.