### PR TITLE
fix(deps): update vulnerable dependencies for cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdff496dd4e98a81f4861e66f7eaf5f2488971848bb42d9c892f871730245c8"
+checksum = "cc2db5c583aaef0255aa63a4fe827f826090142528bba48d1bf4119b62780cad"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3661,9 +3661,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -3964,9 +3964,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5befb5191be3584a4edaf63435e8ff92ffff622e711ca7e77f8f8f365a9df8"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.3",
+ "libm",
+ "rand 0.9.1",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,6 +3678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
+ "fastbloom",
  "getrandom 0.3.3",
  "lru-slab",
  "rand 0.9.1",
@@ -4414,6 +4427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,6 +4932,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4982,6 +5002,7 @@ dependencies = [
  "hex",
  "num-bigint",
  "once_cell",
+ "quinn-proto",
  "reqwest",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ serde_json = "1.0.105"
 thiserror = "1.0.69"
 tokio = { version = "1.38.0", features = ["full"] }
 tycho-common = ">=0.143.0"
+# Force minimum version to fix RUSTSEC-2026-0037
+quinn-proto = "0.11.14"
 
 alloy = { version = "1.0.35", features = [
     "providers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = "1.0.69"
 tokio = { version = "1.38.0", features = ["full"] }
 tycho-common = ">=0.143.0"
 # Force minimum version to fix RUSTSEC-2026-0037
-quinn-proto = "0.11.14"
+quinn-proto = { version = "0.11.14", optional = true }
 
 alloy = { version = "1.0.35", features = [
     "providers",
@@ -56,7 +56,7 @@ tycho-execution = { path = "../tycho-execution", features = ["test-utils"] }
 
 [features]
 default = ["evm"]
-evm = ["alloy", "reqwest"]
+evm = ["alloy", "reqwest", "quinn-proto"]
 fork-tests = []
 test-utils = ["async-trait", "typetag"]
 


### PR DESCRIPTION
## Summary

- Add minimum version constraint for `quinn-proto >= 0.11.14` in `Cargo.toml` to protect downstream consumers (RUSTSEC-2026-0037)
- Update `Cargo.lock`: quinn-proto 0.11.12 → 0.11.14, alloy-dyn-abi and ruint to latest compatible versions

The security audit CI workflow already exists on main. This PR ensures it passes with current advisory database and adds the `Cargo.toml` constraint so downstream consumers inherit the fix.

## Test plan

- [x] `cargo audit` passes locally with 0 vulnerabilities
- [ ] Security audit CI passes on this PR

Related: [ENG-5667](https://propeller-heads.atlassian.net/browse/ENG-5667)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-5667]: https://propeller-heads.atlassian.net/browse/ENG-5667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ